### PR TITLE
feat: Stats improvement

### DIFF
--- a/abi/erc20.json
+++ b/abi/erc20.json
@@ -1,0 +1,222 @@
+[
+  {
+      "constant": true,
+      "inputs": [],
+      "name": "name",
+      "outputs": [
+          {
+              "name": "",
+              "type": "string"
+          }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+  },
+  {
+      "constant": false,
+      "inputs": [
+          {
+              "name": "_spender",
+              "type": "address"
+          },
+          {
+              "name": "_value",
+              "type": "uint256"
+          }
+      ],
+      "name": "approve",
+      "outputs": [
+          {
+              "name": "",
+              "type": "bool"
+          }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+  },
+  {
+      "constant": true,
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [
+          {
+              "name": "",
+              "type": "uint256"
+          }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+  },
+  {
+      "constant": false,
+      "inputs": [
+          {
+              "name": "_from",
+              "type": "address"
+          },
+          {
+              "name": "_to",
+              "type": "address"
+          },
+          {
+              "name": "_value",
+              "type": "uint256"
+          }
+      ],
+      "name": "transferFrom",
+      "outputs": [
+          {
+              "name": "",
+              "type": "bool"
+          }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+  },
+  {
+      "constant": true,
+      "inputs": [],
+      "name": "decimals",
+      "outputs": [
+          {
+              "name": "",
+              "type": "uint8"
+          }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+  },
+  {
+      "constant": true,
+      "inputs": [
+          {
+              "name": "_owner",
+              "type": "address"
+          }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+          {
+              "name": "balance",
+              "type": "uint256"
+          }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+  },
+  {
+      "constant": true,
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [
+          {
+              "name": "",
+              "type": "string"
+          }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+  },
+  {
+      "constant": false,
+      "inputs": [
+          {
+              "name": "_to",
+              "type": "address"
+          },
+          {
+              "name": "_value",
+              "type": "uint256"
+          }
+      ],
+      "name": "transfer",
+      "outputs": [
+          {
+              "name": "",
+              "type": "bool"
+          }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+  },
+  {
+      "constant": true,
+      "inputs": [
+          {
+              "name": "_owner",
+              "type": "address"
+          },
+          {
+              "name": "_spender",
+              "type": "address"
+          }
+      ],
+      "name": "allowance",
+      "outputs": [
+          {
+              "name": "",
+              "type": "uint256"
+          }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+  },
+  {
+      "payable": true,
+      "stateMutability": "payable",
+      "type": "fallback"
+  },
+  {
+      "anonymous": false,
+      "inputs": [
+          {
+              "indexed": true,
+              "name": "owner",
+              "type": "address"
+          },
+          {
+              "indexed": true,
+              "name": "spender",
+              "type": "address"
+          },
+          {
+              "indexed": false,
+              "name": "value",
+              "type": "uint256"
+          }
+      ],
+      "name": "Approval",
+      "type": "event"
+  },
+  {
+      "anonymous": false,
+      "inputs": [
+          {
+              "indexed": true,
+              "name": "from",
+              "type": "address"
+          },
+          {
+              "indexed": true,
+              "name": "to",
+              "type": "address"
+          },
+          {
+              "indexed": false,
+              "name": "value",
+              "type": "uint256"
+          }
+      ],
+      "name": "Transfer",
+      "type": "event"
+  }
+]

--- a/db/migrations/1746794180946-Data.js
+++ b/db/migrations/1746794180946-Data.js
@@ -1,47 +1,92 @@
 module.exports = class Data1746794180946 {
-    name = 'Data1746794180946'
+  name = "Data1746794180946";
 
-    async up(db) {
-        await db.query(`CREATE TABLE "user_credit_stats" ("id" character varying NOT NULL, "address" text NOT NULL, "total_credits_consumed" numeric NOT NULL, "last_credit_usage" TIMESTAMP WITH TIME ZONE, CONSTRAINT "PK_bcad8f413f718359398e798c9ae" PRIMARY KEY ("id"))`)
-        await db.query(`CREATE INDEX "IDX_766ea4ab6ae127b6b9d7f7b6c4" ON "user_credit_stats" ("address") `)
-        await db.query(`CREATE TABLE "credit_consumption" ("id" character varying NOT NULL, "credit_id" text NOT NULL, "contract" text NOT NULL, "amount" numeric NOT NULL, "timestamp" TIMESTAMP WITH TIME ZONE NOT NULL, "block" integer NOT NULL, "tx_hash" text NOT NULL, "beneficiary_id" character varying, CONSTRAINT "PK_e6419ee754be1f85ef1bdf3303b" PRIMARY KEY ("id"))`)
-        await db.query(`CREATE INDEX "IDX_f70643cdcb5d34c397f5400cc3" ON "credit_consumption" ("credit_id") `)
-        await db.query(`CREATE INDEX "IDX_aeda08f9257733a47ae7a8407d" ON "credit_consumption" ("beneficiary_id") `)
-        await db.query(`CREATE INDEX "IDX_d3b724c7a5d9b9f19af5c596cf" ON "credit_consumption" ("contract") `)
-        await db.query(`CREATE INDEX "IDX_ee0233b512bc1e86f6276fecf8" ON "credit_consumption" ("tx_hash") `)
-        await db.query(`CREATE TABLE "mana_transaction" ("id" character varying NOT NULL, "tx_hash" text NOT NULL, "from_address" text NOT NULL, "to_address" text NOT NULL, "total_mana_amount" numeric NOT NULL, "credit_amount" numeric, "user_paid_amount" numeric, "dao_fee_amount" numeric, "related_consumption_ids" text array, "timestamp" TIMESTAMP WITH TIME ZONE NOT NULL, "block" integer NOT NULL, CONSTRAINT "PK_267a908dd35f05c17a281fb2341" PRIMARY KEY ("id"))`)
-        await db.query(`CREATE INDEX "IDX_925948d142bce0efe8c4100ca0" ON "mana_transaction" ("tx_hash") `)
-        await db.query(`CREATE INDEX "IDX_3d761c1f4ed5f31f8786ec7419" ON "mana_transaction" ("from_address") `)
-        await db.query(`CREATE INDEX "IDX_3ce3cd15a6b59c67e6e7f6cd90" ON "mana_transaction" ("to_address") `)
-        await db.query(`CREATE TABLE "hourly_credit_usage" ("id" character varying NOT NULL, "total_amount" numeric NOT NULL, "usage_count" integer NOT NULL, "timestamp" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "PK_2dd4c7d6b79896f6b908280d2fc" PRIMARY KEY ("id"))`)
-        await db.query(`CREATE TABLE "daily_credit_usage" ("id" character varying NOT NULL, "total_amount" numeric NOT NULL, "unique_users" integer NOT NULL, "usage_count" integer NOT NULL, "timestamp" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "PK_b69b3f47600e3870274969ebbb9" PRIMARY KEY ("id"))`)
-        await db.query(`CREATE TABLE "marketplace_credit_usage" ("id" character varying NOT NULL, "asset_id" text NOT NULL, "collection_address" text NOT NULL, "is_primary_sale" boolean NOT NULL, "price" numeric NOT NULL, "credit_consumption_id" character varying, CONSTRAINT "PK_24836a8c692bee0433f8fb8b36a" PRIMARY KEY ("id"))`)
-        await db.query(`CREATE INDEX "IDX_e5647789223aecfbf3780e1581" ON "marketplace_credit_usage" ("credit_consumption_id") `)
-        await db.query(`CREATE INDEX "IDX_89057e613d380ae4177118da0f" ON "marketplace_credit_usage" ("asset_id") `)
-        await db.query(`CREATE INDEX "IDX_3c0a44b2eafee0a08e3e6f4deb" ON "marketplace_credit_usage" ("collection_address") `)
-        await db.query(`ALTER TABLE "credit_consumption" ADD CONSTRAINT "FK_aeda08f9257733a47ae7a8407d7" FOREIGN KEY ("beneficiary_id") REFERENCES "user_credit_stats"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`)
-        await db.query(`ALTER TABLE "marketplace_credit_usage" ADD CONSTRAINT "FK_e5647789223aecfbf3780e1581e" FOREIGN KEY ("credit_consumption_id") REFERENCES "credit_consumption"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`)
-    }
+  async up(db) {
+    await db.query(
+      `CREATE TABLE "user_credit_stats" ("id" character varying NOT NULL, "address" text NOT NULL, "total_credits_consumed" numeric NOT NULL, "last_credit_usage" TIMESTAMP WITH TIME ZONE, CONSTRAINT "PK_bcad8f413f718359398e798c9ae" PRIMARY KEY ("id"))`
+    );
+    await db.query(
+      `CREATE INDEX "IDX_766ea4ab6ae127b6b9d7f7b6c4" ON "user_credit_stats" ("address") `
+    );
+    await db.query(
+      `CREATE TABLE "credit_consumption" ("id" character varying NOT NULL, "credit_id" text NOT NULL, "contract" text NOT NULL, "amount" numeric NOT NULL, "timestamp" TIMESTAMP WITH TIME ZONE NOT NULL, "block" integer NOT NULL, "tx_hash" text NOT NULL, "beneficiary_id" character varying, CONSTRAINT "PK_e6419ee754be1f85ef1bdf3303b" PRIMARY KEY ("id"))`
+    );
+    await db.query(
+      `CREATE INDEX "IDX_f70643cdcb5d34c397f5400cc3" ON "credit_consumption" ("credit_id") `
+    );
+    await db.query(
+      `CREATE INDEX "IDX_aeda08f9257733a47ae7a8407d" ON "credit_consumption" ("beneficiary_id") `
+    );
+    await db.query(
+      `CREATE INDEX "IDX_d3b724c7a5d9b9f19af5c596cf" ON "credit_consumption" ("contract") `
+    );
+    await db.query(
+      `CREATE INDEX "IDX_ee0233b512bc1e86f6276fecf8" ON "credit_consumption" ("tx_hash") `
+    );
+    await db.query(
+      `CREATE TABLE "mana_transaction" ("id" character varying NOT NULL, "tx_hash" text NOT NULL, "from_address" text NOT NULL, "to_address" text NOT NULL, "total_mana_amount" numeric NOT NULL, "credit_amount" numeric, "user_paid_amount" numeric, "dao_fee_amount" numeric, "related_consumption_ids" text array, "timestamp" TIMESTAMP WITH TIME ZONE NOT NULL, "block" integer NOT NULL, CONSTRAINT "PK_267a908dd35f05c17a281fb2341" PRIMARY KEY ("id"))`
+    );
+    await db.query(
+      `CREATE INDEX "IDX_925948d142bce0efe8c4100ca0" ON "mana_transaction" ("tx_hash") `
+    );
+    await db.query(
+      `CREATE INDEX "IDX_3d761c1f4ed5f31f8786ec7419" ON "mana_transaction" ("from_address") `
+    );
+    await db.query(
+      `CREATE INDEX "IDX_3ce3cd15a6b59c67e6e7f6cd90" ON "mana_transaction" ("to_address") `
+    );
+    await db.query(
+      `CREATE TABLE "hourly_credit_usage" ("id" character varying NOT NULL, "total_amount" numeric NOT NULL, "usage_count" integer NOT NULL, "timestamp" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "PK_2dd4c7d6b79896f6b908280d2fc" PRIMARY KEY ("id"))`
+    );
+    await db.query(
+      `CREATE TABLE "daily_credit_usage" ("id" character varying NOT NULL, "total_amount" numeric NOT NULL, "unique_users" integer NOT NULL, "usage_count" integer NOT NULL, "timestamp" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "PK_b69b3f47600e3870274969ebbb9" PRIMARY KEY ("id"))`
+    );
+    await db.query(
+      `CREATE TABLE "marketplace_credit_usage" ("id" character varying NOT NULL, "asset_id" text NOT NULL, "collection_address" text NOT NULL, "is_primary_sale" boolean NOT NULL, "price" numeric NOT NULL, "credit_consumption_id" character varying, CONSTRAINT "PK_24836a8c692bee0433f8fb8b36a" PRIMARY KEY ("id"))`
+    );
+    await db.query(
+      `CREATE INDEX "IDX_e5647789223aecfbf3780e1581" ON "marketplace_credit_usage" ("credit_consumption_id") `
+    );
+    await db.query(
+      `CREATE INDEX "IDX_89057e613d380ae4177118da0f" ON "marketplace_credit_usage" ("asset_id") `
+    );
+    await db.query(
+      `CREATE INDEX "IDX_3c0a44b2eafee0a08e3e6f4deb" ON "marketplace_credit_usage" ("collection_address") `
+    );
+    await db.query(
+      `ALTER TABLE "credit_consumption" ADD CONSTRAINT "FK_aeda08f9257733a47ae7a8407d7" FOREIGN KEY ("beneficiary_id") REFERENCES "user_credit_stats"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await db.query(
+      `ALTER TABLE "marketplace_credit_usage" ADD CONSTRAINT "FK_e5647789223aecfbf3780e1581e" FOREIGN KEY ("credit_consumption_id") REFERENCES "credit_consumption"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+    );
+    await db.query(
+      `CREATE TRIGGER credit_consumption_changes_trigger AFTER INSERT OR UPDATE OR DELETE ON credit_consumption FOR EACH ROW EXECUTE FUNCTION notify_credit_changes();`
+    );
+  }
 
-    async down(db) {
-        await db.query(`DROP TABLE "user_credit_stats"`)
-        await db.query(`DROP INDEX "public"."IDX_766ea4ab6ae127b6b9d7f7b6c4"`)
-        await db.query(`DROP TABLE "credit_consumption"`)
-        await db.query(`DROP INDEX "public"."IDX_f70643cdcb5d34c397f5400cc3"`)
-        await db.query(`DROP INDEX "public"."IDX_aeda08f9257733a47ae7a8407d"`)
-        await db.query(`DROP INDEX "public"."IDX_d3b724c7a5d9b9f19af5c596cf"`)
-        await db.query(`DROP INDEX "public"."IDX_ee0233b512bc1e86f6276fecf8"`)
-        await db.query(`DROP TABLE "mana_transaction"`)
-        await db.query(`DROP INDEX "public"."IDX_925948d142bce0efe8c4100ca0"`)
-        await db.query(`DROP INDEX "public"."IDX_3d761c1f4ed5f31f8786ec7419"`)
-        await db.query(`DROP INDEX "public"."IDX_3ce3cd15a6b59c67e6e7f6cd90"`)
-        await db.query(`DROP TABLE "hourly_credit_usage"`)
-        await db.query(`DROP TABLE "daily_credit_usage"`)
-        await db.query(`DROP TABLE "marketplace_credit_usage"`)
-        await db.query(`DROP INDEX "public"."IDX_e5647789223aecfbf3780e1581"`)
-        await db.query(`DROP INDEX "public"."IDX_89057e613d380ae4177118da0f"`)
-        await db.query(`DROP INDEX "public"."IDX_3c0a44b2eafee0a08e3e6f4deb"`)
-        await db.query(`ALTER TABLE "credit_consumption" DROP CONSTRAINT "FK_aeda08f9257733a47ae7a8407d7"`)
-        await db.query(`ALTER TABLE "marketplace_credit_usage" DROP CONSTRAINT "FK_e5647789223aecfbf3780e1581e"`)
-    }
-}
+  async down(db) {
+    await db.query(`DROP TABLE "user_credit_stats"`);
+    await db.query(`DROP INDEX "public"."IDX_766ea4ab6ae127b6b9d7f7b6c4"`);
+    await db.query(`DROP TABLE "credit_consumption"`);
+    await db.query(`DROP INDEX "public"."IDX_f70643cdcb5d34c397f5400cc3"`);
+    await db.query(`DROP INDEX "public"."IDX_aeda08f9257733a47ae7a8407d"`);
+    await db.query(`DROP INDEX "public"."IDX_d3b724c7a5d9b9f19af5c596cf"`);
+    await db.query(`DROP INDEX "public"."IDX_ee0233b512bc1e86f6276fecf8"`);
+    await db.query(`DROP TABLE "mana_transaction"`);
+    await db.query(`DROP INDEX "public"."IDX_925948d142bce0efe8c4100ca0"`);
+    await db.query(`DROP INDEX "public"."IDX_3d761c1f4ed5f31f8786ec7419"`);
+    await db.query(`DROP INDEX "public"."IDX_3ce3cd15a6b59c67e6e7f6cd90"`);
+    await db.query(`DROP TABLE "hourly_credit_usage"`);
+    await db.query(`DROP TABLE "daily_credit_usage"`);
+    await db.query(`DROP TABLE "marketplace_credit_usage"`);
+    await db.query(`DROP INDEX "public"."IDX_e5647789223aecfbf3780e1581"`);
+    await db.query(`DROP INDEX "public"."IDX_89057e613d380ae4177118da0f"`);
+    await db.query(`DROP INDEX "public"."IDX_3c0a44b2eafee0a08e3e6f4deb"`);
+    await db.query(
+      `ALTER TABLE "credit_consumption" DROP CONSTRAINT "FK_aeda08f9257733a47ae7a8407d7"`
+    );
+    await db.query(
+      `ALTER TABLE "marketplace_credit_usage" DROP CONSTRAINT "FK_e5647789223aecfbf3780e1581e"`
+    );
+  }
+};

--- a/db/migrations/1746794180946-Data.js
+++ b/db/migrations/1746794180946-Data.js
@@ -1,5 +1,5 @@
-module.exports = class Data1743510447782 {
-    name = 'Data1743510447782'
+module.exports = class Data1746794180946 {
+    name = 'Data1746794180946'
 
     async up(db) {
         await db.query(`CREATE TABLE "user_credit_stats" ("id" character varying NOT NULL, "address" text NOT NULL, "total_credits_consumed" numeric NOT NULL, "last_credit_usage" TIMESTAMP WITH TIME ZONE, CONSTRAINT "PK_bcad8f413f718359398e798c9ae" PRIMARY KEY ("id"))`)
@@ -9,6 +9,10 @@ module.exports = class Data1743510447782 {
         await db.query(`CREATE INDEX "IDX_aeda08f9257733a47ae7a8407d" ON "credit_consumption" ("beneficiary_id") `)
         await db.query(`CREATE INDEX "IDX_d3b724c7a5d9b9f19af5c596cf" ON "credit_consumption" ("contract") `)
         await db.query(`CREATE INDEX "IDX_ee0233b512bc1e86f6276fecf8" ON "credit_consumption" ("tx_hash") `)
+        await db.query(`CREATE TABLE "mana_transaction" ("id" character varying NOT NULL, "tx_hash" text NOT NULL, "from_address" text NOT NULL, "to_address" text NOT NULL, "total_mana_amount" numeric NOT NULL, "credit_amount" numeric, "user_paid_amount" numeric, "dao_fee_amount" numeric, "related_consumption_ids" text array, "timestamp" TIMESTAMP WITH TIME ZONE NOT NULL, "block" integer NOT NULL, CONSTRAINT "PK_267a908dd35f05c17a281fb2341" PRIMARY KEY ("id"))`)
+        await db.query(`CREATE INDEX "IDX_925948d142bce0efe8c4100ca0" ON "mana_transaction" ("tx_hash") `)
+        await db.query(`CREATE INDEX "IDX_3d761c1f4ed5f31f8786ec7419" ON "mana_transaction" ("from_address") `)
+        await db.query(`CREATE INDEX "IDX_3ce3cd15a6b59c67e6e7f6cd90" ON "mana_transaction" ("to_address") `)
         await db.query(`CREATE TABLE "hourly_credit_usage" ("id" character varying NOT NULL, "total_amount" numeric NOT NULL, "usage_count" integer NOT NULL, "timestamp" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "PK_2dd4c7d6b79896f6b908280d2fc" PRIMARY KEY ("id"))`)
         await db.query(`CREATE TABLE "daily_credit_usage" ("id" character varying NOT NULL, "total_amount" numeric NOT NULL, "unique_users" integer NOT NULL, "usage_count" integer NOT NULL, "timestamp" TIMESTAMP WITH TIME ZONE NOT NULL, CONSTRAINT "PK_b69b3f47600e3870274969ebbb9" PRIMARY KEY ("id"))`)
         await db.query(`CREATE TABLE "marketplace_credit_usage" ("id" character varying NOT NULL, "asset_id" text NOT NULL, "collection_address" text NOT NULL, "is_primary_sale" boolean NOT NULL, "price" numeric NOT NULL, "credit_consumption_id" character varying, CONSTRAINT "PK_24836a8c692bee0433f8fb8b36a" PRIMARY KEY ("id"))`)
@@ -27,6 +31,10 @@ module.exports = class Data1743510447782 {
         await db.query(`DROP INDEX "public"."IDX_aeda08f9257733a47ae7a8407d"`)
         await db.query(`DROP INDEX "public"."IDX_d3b724c7a5d9b9f19af5c596cf"`)
         await db.query(`DROP INDEX "public"."IDX_ee0233b512bc1e86f6276fecf8"`)
+        await db.query(`DROP TABLE "mana_transaction"`)
+        await db.query(`DROP INDEX "public"."IDX_925948d142bce0efe8c4100ca0"`)
+        await db.query(`DROP INDEX "public"."IDX_3d761c1f4ed5f31f8786ec7419"`)
+        await db.query(`DROP INDEX "public"."IDX_3ce3cd15a6b59c67e6e7f6cd90"`)
         await db.query(`DROP TABLE "hourly_credit_usage"`)
         await db.query(`DROP TABLE "daily_credit_usage"`)
         await db.query(`DROP TABLE "marketplace_credit_usage"`)

--- a/indexer.sh
+++ b/indexer.sh
@@ -2,8 +2,8 @@
 
 # Generate a unique schema name and user credentials using a timestamp
 CURRENT_TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
-NEW_SCHEMA_NAME="credits_squid_${CURRENT_TIMESTAMP}"
-NEW_DB_USER="credits_squid_user_${CURRENT_TIMESTAMP}"
+NEW_SCHEMA_NAME="squid_credits_${CURRENT_TIMESTAMP}"
+NEW_DB_USER="squid_credits_user_${CURRENT_TIMESTAMP}"
 CREDITS_SERVER_API_READER_USER="credits_server_user"
 SQUIDS_PUBLIC_TABLE="squids"
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -13,6 +13,23 @@ type CreditConsumption @entity {
 }
 
 """
+Tracks MANA transactions correlated with credit usage
+"""
+type ManaTransaction @entity {
+  id: ID! # Transaction hash + event index
+  txHash: String! @index # Transaction hash
+  fromAddress: String! @index # Sender of MANA
+  toAddress: String! @index # Receiver of MANA
+  totalManaAmount: BigInt! # Total MANA amount in the transaction
+  creditAmount: BigInt # Amount of credits used (if applicable)
+  userPaidAmount: BigInt # Amount paid directly by the user
+  daoFeeAmount: BigInt # Amount of MANA paid as DAO fee
+  relatedConsumptionIds: [String!] # Array of related credit consumption IDs
+  timestamp: DateTime! # When the transaction occurred
+  block: Int! # Block number
+}
+
+"""
 Tracks aggregated credit usage per user
 """
 type UserCreditStats @entity {

--- a/src/abi/erc20.ts
+++ b/src/abi/erc20.ts
@@ -1,0 +1,80 @@
+import * as p from '@subsquid/evm-codec'
+import { event, fun, viewFun, indexed, ContractBase } from '@subsquid/evm-abi'
+import type { EventParams as EParams, FunctionArguments, FunctionReturn } from '@subsquid/evm-abi'
+
+export const events = {
+    Approval: event("0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925", "Approval(address,address,uint256)", {"owner": indexed(p.address), "spender": indexed(p.address), "value": p.uint256}),
+    Transfer: event("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "Transfer(address,address,uint256)", {"from": indexed(p.address), "to": indexed(p.address), "value": p.uint256}),
+}
+
+export const functions = {
+    name: viewFun("0x06fdde03", "name()", {}, p.string),
+    approve: fun("0x095ea7b3", "approve(address,uint256)", {"_spender": p.address, "_value": p.uint256}, p.bool),
+    totalSupply: viewFun("0x18160ddd", "totalSupply()", {}, p.uint256),
+    transferFrom: fun("0x23b872dd", "transferFrom(address,address,uint256)", {"_from": p.address, "_to": p.address, "_value": p.uint256}, p.bool),
+    decimals: viewFun("0x313ce567", "decimals()", {}, p.uint8),
+    balanceOf: viewFun("0x70a08231", "balanceOf(address)", {"_owner": p.address}, p.uint256),
+    symbol: viewFun("0x95d89b41", "symbol()", {}, p.string),
+    transfer: fun("0xa9059cbb", "transfer(address,uint256)", {"_to": p.address, "_value": p.uint256}, p.bool),
+    allowance: viewFun("0xdd62ed3e", "allowance(address,address)", {"_owner": p.address, "_spender": p.address}, p.uint256),
+}
+
+export class Contract extends ContractBase {
+
+    name() {
+        return this.eth_call(functions.name, {})
+    }
+
+    totalSupply() {
+        return this.eth_call(functions.totalSupply, {})
+    }
+
+    decimals() {
+        return this.eth_call(functions.decimals, {})
+    }
+
+    balanceOf(_owner: BalanceOfParams["_owner"]) {
+        return this.eth_call(functions.balanceOf, {_owner})
+    }
+
+    symbol() {
+        return this.eth_call(functions.symbol, {})
+    }
+
+    allowance(_owner: AllowanceParams["_owner"], _spender: AllowanceParams["_spender"]) {
+        return this.eth_call(functions.allowance, {_owner, _spender})
+    }
+}
+
+/// Event types
+export type ApprovalEventArgs = EParams<typeof events.Approval>
+export type TransferEventArgs = EParams<typeof events.Transfer>
+
+/// Function types
+export type NameParams = FunctionArguments<typeof functions.name>
+export type NameReturn = FunctionReturn<typeof functions.name>
+
+export type ApproveParams = FunctionArguments<typeof functions.approve>
+export type ApproveReturn = FunctionReturn<typeof functions.approve>
+
+export type TotalSupplyParams = FunctionArguments<typeof functions.totalSupply>
+export type TotalSupplyReturn = FunctionReturn<typeof functions.totalSupply>
+
+export type TransferFromParams = FunctionArguments<typeof functions.transferFrom>
+export type TransferFromReturn = FunctionReturn<typeof functions.transferFrom>
+
+export type DecimalsParams = FunctionArguments<typeof functions.decimals>
+export type DecimalsReturn = FunctionReturn<typeof functions.decimals>
+
+export type BalanceOfParams = FunctionArguments<typeof functions.balanceOf>
+export type BalanceOfReturn = FunctionReturn<typeof functions.balanceOf>
+
+export type SymbolParams = FunctionArguments<typeof functions.symbol>
+export type SymbolReturn = FunctionReturn<typeof functions.symbol>
+
+export type TransferParams = FunctionArguments<typeof functions.transfer>
+export type TransferReturn = FunctionReturn<typeof functions.transfer>
+
+export type AllowanceParams = FunctionArguments<typeof functions.allowance>
+export type AllowanceReturn = FunctionReturn<typeof functions.allowance>
+

--- a/src/mana.ts
+++ b/src/mana.ts
@@ -1,0 +1,605 @@
+import { Store } from "@subsquid/typeorm-store";
+import { Log } from "@subsquid/evm-processor";
+import { CreditConsumption, ManaTransaction } from "./model";
+import { formatMana, formatAddress } from "./utils";
+
+// DAO address that receives fees
+const DAO_ADDRESS = "0xb08e3e7cc815213304d884c88ca476ebc50eaab2";
+
+/**
+ * Transaction data structure with all relevant information
+ */
+interface TransactionData {
+  transfers: Array<{
+    fromAddress: string;
+    toAddress: string;
+    totalManaAmount: bigint;
+    timestamp: Date;
+    block: number;
+    logIndex: number;
+    isDaoFee: boolean;
+  }>;
+  creditBeneficiaries: string[]; // Array of users who benefited from credits in this tx
+  totalDaoFees: bigint;
+  timestamp: Date;
+  block: number;
+}
+
+/**
+ * Map to track MANA transfers by transaction hash for correlation with credit usage
+ */
+const pendingTransactions = new Map<string, TransactionData>();
+
+/**
+ * Map to track credit consumptions by transaction hash for correlation with MANA transfers
+ * Each transaction hash can have multiple consumptions
+ */
+const pendingCreditConsumptions = new Map<string, CreditConsumption[]>();
+
+/**
+ * Process a MANA transfer event
+ */
+export function processManaTransfer(
+  store: Store,
+  log: Log & { transactionHash: string },
+  from: string,
+  to: string,
+  amount: bigint,
+  timestamp: Date,
+  block: number,
+  creditsContractAddress: string
+): void {
+  // Get transaction hash via the transaction accessor
+  const txHash = log.transactionHash;
+  if (!txHash) {
+    console.log(
+      "[MANA] ERROR: No transaction hash available for MANA transfer"
+    );
+    return;
+  }
+
+  // Normalize addresses for comparison
+  const normalizedFrom = from.toLowerCase();
+  const normalizedTo = to.toLowerCase();
+  const normalizedCreditsContract = creditsContractAddress.toLowerCase();
+
+  // Check if this is a credits-related transfer
+  const isCreditsInvolved =
+    normalizedFrom === normalizedCreditsContract ||
+    normalizedTo === normalizedCreditsContract;
+
+  // Check if this is a DAO fee transfer
+  const isDaoFee = normalizedTo === DAO_ADDRESS;
+
+  // We also want to track transfers FROM a beneficiary as they might be paying for credits
+  const isPotentialUserPayment = pendingCreditConsumptions.has(txHash);
+
+  // We only want to track:
+  // 1. Credits-related transfers
+  // 2. DAO fees ONLY if we're already tracking the transaction (involves credits)
+  // 3. User payments for transactions with pending credit consumptions
+  if (
+    !isCreditsInvolved &&
+    !(isDaoFee && pendingTransactions.has(txHash)) &&
+    !isPotentialUserPayment
+  ) {
+    return;
+  }
+
+  // Initialize transaction data if not already tracking
+  if (!pendingTransactions.has(txHash)) {
+    pendingTransactions.set(txHash, {
+      transfers: [],
+      creditBeneficiaries: [],
+      totalDaoFees: 0n,
+      timestamp,
+      block,
+    });
+  }
+
+  // Get the transaction data
+  const txData = pendingTransactions.get(txHash)!;
+
+  // Add this transfer
+  txData.transfers.push({
+    fromAddress: normalizedFrom,
+    toAddress: normalizedTo,
+    totalManaAmount: amount,
+    timestamp,
+    block,
+    logIndex: log.logIndex,
+    isDaoFee,
+  });
+
+  // Add to DAO fees if applicable
+  if (isDaoFee) {
+    txData.totalDaoFees += amount;
+    console.log(`[MANA] 💰 DAO fee for tx ${txHash}: ${formatMana(amount)}`);
+  }
+
+  console.log(
+    `[MANA] 🪙 Credits transfer: ${normalizedFrom} → ${normalizedTo}, amount: ${formatMana(
+      amount
+    )}`
+  );
+
+  // Check if we already have matching credit consumptions
+  if (pendingCreditConsumptions.has(txHash)) {
+    const creditConsumptions = pendingCreditConsumptions.get(txHash)!;
+    if (creditConsumptions.length > 1) {
+      console.log(
+        `[MANA] Processing ${creditConsumptions.length} consumptions for tx ${txHash}`
+      );
+    }
+
+    // Process each credit consumption
+    for (const creditConsumption of creditConsumptions) {
+      createManaTransaction(store, txHash, creditConsumption);
+    }
+  }
+}
+
+/**
+ * Process a credit consumption event
+ */
+export async function registerCreditConsumption(
+  store: Store,
+  creditConsumption: CreditConsumption
+): Promise<void> {
+  const txHash = creditConsumption.txHash;
+  const consumptionId = creditConsumption.id;
+
+  // Initialize the array if it doesn't exist
+  if (!pendingCreditConsumptions.has(txHash)) {
+    pendingCreditConsumptions.set(txHash, []);
+  }
+
+  // Add this consumption to the array for this transaction
+  const consumptions = pendingCreditConsumptions.get(txHash)!;
+
+  // Check if this specific consumption is already in the array (avoid duplicates)
+  const existingIndex = consumptions.findIndex((c) => c.id === consumptionId);
+  if (existingIndex >= 0) {
+    console.log(
+      `[CREDITS] ERROR: Consumption ${consumptionId} already registered for tx ${txHash}, skipping`
+    );
+    return;
+  }
+
+  // Add to the array of consumptions for this transaction
+  consumptions.push(creditConsumption);
+
+  // Store the beneficiary address if we're already tracking this transaction
+  if (pendingTransactions.has(txHash)) {
+    const txData = pendingTransactions.get(txHash)!;
+    const beneficiaryId = creditConsumption.beneficiary.id.toLowerCase();
+
+    // Add to the array of beneficiaries if not already there
+    if (!txData.creditBeneficiaries.includes(beneficiaryId)) {
+      txData.creditBeneficiaries.push(beneficiaryId);
+    }
+
+    // Process this consumption immediately if we already have the transaction data
+    await createManaTransaction(store, txHash, creditConsumption);
+  } else {
+    console.log(
+      `[CREDITS] ⚠️ WARNING: No MANA transfer found yet for consumption in tx ${txHash}`
+    );
+
+    // Check if transaction already exists in database but was processed in a previous batch
+    try {
+      // Query with a prefix search for any transaction with this txHash
+      const existingTransactions = await store.find(ManaTransaction, {
+        where: { txHash },
+      });
+
+      if (existingTransactions.length > 0) {
+        // Update each existing transaction with this consumption ID
+        for (const existingTx of existingTransactions) {
+          // Get existing relatedConsumptionIds or initialize an empty array
+          const relatedIds = existingTx.relatedConsumptionIds || [];
+
+          // Add this consumption ID if not already present
+          if (!relatedIds.includes(consumptionId)) {
+            relatedIds.push(consumptionId);
+            existingTx.relatedConsumptionIds = relatedIds;
+
+            // Update credit amount
+            if (!existingTx.creditAmount) {
+              existingTx.creditAmount = creditConsumption.amount;
+            } else {
+              existingTx.creditAmount += creditConsumption.amount;
+            }
+
+            // Save the updated transaction
+            await store.save(existingTx);
+            console.log(
+              `[CREDITS] Updated transaction ${existingTx.id} with consumption ${consumptionId}`
+            );
+
+            // Remove this consumption from pending since it's been processed
+            const updatedConsumptions = consumptions.filter(
+              (c) => c.id !== consumptionId
+            );
+            if (updatedConsumptions.length === 0) {
+              pendingCreditConsumptions.delete(txHash);
+            } else {
+              pendingCreditConsumptions.set(txHash, updatedConsumptions);
+            }
+
+            return; // Successfully processed this consumption
+          }
+        }
+      }
+    } catch (error) {
+      console.error(
+        `[CREDITS] ERROR: Failed to check for existing transactions: ${error}`
+      );
+    }
+  }
+}
+
+/**
+ * Create a ManaTransaction entity correlating MANA transfer with credit consumption
+ */
+export async function createManaTransaction(
+  store: Store,
+  txHash: string,
+  creditConsumption?: CreditConsumption
+): Promise<void> {
+  // Get the transaction data
+  const txData = pendingTransactions.get(txHash);
+  if (!txData || txData.transfers.length === 0) {
+    console.log(`[MANA] ERROR: No MANA transfers found for tx ${txHash}`);
+    return;
+  }
+
+  // Add beneficiary from credit consumption if not already set
+  if (
+    creditConsumption &&
+    !txData.creditBeneficiaries.includes(
+      creditConsumption.beneficiary.id.toLowerCase()
+    )
+  ) {
+    txData.creditBeneficiaries.push(
+      creditConsumption.beneficiary.id.toLowerCase()
+    );
+  }
+
+  // Get the main transfers (not DAO fees) sorted by amount
+  const mainTransfers = txData.transfers
+    .filter((t) => !t.isDaoFee)
+    .sort((a, b) =>
+      b.totalManaAmount > a.totalManaAmount
+        ? 1
+        : b.totalManaAmount < a.totalManaAmount
+        ? -1
+        : 0
+    );
+
+  if (mainTransfers.length === 0) {
+    console.log(
+      `[MANA] ERROR: Only found DAO fee transfers for tx ${txHash}, skipping`
+    );
+    return;
+  }
+
+  // The main transfer is usually the largest one from the credits contract
+  const mainTransfer = mainTransfers[0];
+
+  // Find any transfers from the beneficiary (user paid amount)
+  let userPaidAmount = 0n;
+
+  // Check all beneficiaries for this transaction
+  if (txData.creditBeneficiaries.length > 0) {
+    // Find all transfers from any of the beneficiaries
+    const userTransfers = txData.transfers.filter((t) => {
+      return txData.creditBeneficiaries.includes(t.fromAddress) && !t.isDaoFee;
+    });
+
+    userPaidAmount = userTransfers.reduce(
+      (sum, t) => sum + t.totalManaAmount,
+      0n
+    );
+  }
+
+  // Generate a unique ID for the transaction
+  const id = `${txHash}-${mainTransfer.logIndex}`;
+
+  // Get or update existing transaction
+  let manaTransaction: ManaTransaction | undefined;
+  try {
+    manaTransaction = await store.get(ManaTransaction, id);
+  } catch (error) {
+    if (!(error instanceof Error && error.message.includes("not found"))) {
+      console.error(
+        `[MANA] ERROR: Failed to check for existing transaction: ${error}`
+      );
+    }
+  }
+
+  // Initialize the related consumption IDs array
+  let relatedConsumptionIds: string[] = [];
+
+  // If transaction exists, get its existing consumption IDs
+  if (manaTransaction) {
+    relatedConsumptionIds = manaTransaction.relatedConsumptionIds || [];
+  }
+
+  // Add current consumption ID if provided and not already in the array
+  if (
+    creditConsumption &&
+    !relatedConsumptionIds.includes(creditConsumption.id)
+  ) {
+    relatedConsumptionIds.push(creditConsumption.id);
+  }
+
+  // Always check for all consumptions in this transaction, even when processing individual consumption
+  let creditAmount: bigint | null = null;
+
+  if (pendingCreditConsumptions.has(txHash)) {
+    // Sum up all credit consumptions for this transaction
+    creditAmount = pendingCreditConsumptions
+      .get(txHash)!
+      .reduce((sum, consumption) => sum + consumption.amount, 0n);
+
+    // Also add the current consumption if it's not in the pending list
+    if (
+      creditConsumption &&
+      !pendingCreditConsumptions
+        .get(txHash)!
+        .some((c) => c.id === creditConsumption.id)
+    ) {
+      creditAmount += creditConsumption.amount;
+    }
+  } else if (creditConsumption) {
+    // If we don't have any pending consumptions but have the current one
+    creditAmount = creditConsumption.amount;
+  }
+
+  // Calculate total transaction amount
+  const totalAmount = mainTransfer.totalManaAmount + txData.totalDaoFees;
+
+  console.log(`[MANA] 💵 Transaction ${txHash} summary:`);
+  console.log(`  - Total: ${formatMana(totalAmount)}`);
+  console.log(`  - Main: ${formatMana(mainTransfer.totalManaAmount)}`);
+  if (txData.totalDaoFees > 0)
+    console.log(`  - DAO fees: ${formatMana(txData.totalDaoFees)}`);
+  if (creditAmount) console.log(`  - Credits: ${formatMana(creditAmount)}`);
+  if (userPaidAmount > 0)
+    console.log(`  - User paid: ${formatMana(userPaidAmount)}`);
+  console.log(`  - Consumptions: ${relatedConsumptionIds.length}`);
+
+  // Create or update the entity
+  if (!manaTransaction) {
+    // Create new transaction
+    manaTransaction = new ManaTransaction({
+      id,
+      txHash,
+      fromAddress: mainTransfer.fromAddress,
+      toAddress: mainTransfer.toAddress,
+      totalManaAmount: mainTransfer.totalManaAmount,
+      creditAmount,
+      userPaidAmount: userPaidAmount > 0 ? userPaidAmount : null,
+      daoFeeAmount: txData.totalDaoFees > 0 ? txData.totalDaoFees : null,
+      relatedConsumptionIds,
+      timestamp: txData.timestamp,
+      block: txData.block,
+    });
+  } else {
+    // Update existing transaction
+    manaTransaction.totalManaAmount = mainTransfer.totalManaAmount;
+    manaTransaction.creditAmount = creditAmount;
+    manaTransaction.userPaidAmount = userPaidAmount > 0 ? userPaidAmount : null;
+    manaTransaction.daoFeeAmount =
+      txData.totalDaoFees > 0 ? txData.totalDaoFees : null;
+    manaTransaction.relatedConsumptionIds = relatedConsumptionIds;
+  }
+
+  // Save to database
+  try {
+    await store.save(manaTransaction);
+
+    // If this is a specific consumption, mark it as processed by removing from the pending list
+    if (creditConsumption) {
+      const consumptions = pendingCreditConsumptions.get(txHash) || [];
+      const updatedConsumptions = consumptions.filter(
+        (c) => c.id !== creditConsumption.id
+      );
+
+      if (updatedConsumptions.length === 0) {
+        // If no more consumptions for this txHash, remove the entry
+        pendingCreditConsumptions.delete(txHash);
+
+        // Only remove from pendingTransactions if no more consumptions for this txHash
+        pendingTransactions.delete(txHash);
+      } else {
+        // Otherwise update with the remaining consumptions
+        pendingCreditConsumptions.set(txHash, updatedConsumptions);
+      }
+    }
+  } catch (error) {
+    console.error(`[MANA] ERROR: Failed to save transaction: ${error}`);
+  }
+}
+
+/**
+ * Process all pending correlations at the end of a batch
+ */
+export async function processPendingCorrelations(store: Store): Promise<void> {
+  const txCount = pendingTransactions.size;
+
+  // Calculate total pending consumptions
+  let totalPendingConsumptions = 0;
+  for (const consumptions of pendingCreditConsumptions.values()) {
+    totalPendingConsumptions += consumptions.length;
+  }
+
+  const transferCount = Array.from(pendingTransactions.values()).reduce(
+    (sum, tx) => sum + tx.transfers.length,
+    0
+  );
+
+  if (txCount > 0 || totalPendingConsumptions > 0) {
+    console.log(
+      `[MANA] Processing ${txCount} pending transactions with ${transferCount} transfers and ${totalPendingConsumptions} pending consumptions`
+    );
+  } else {
+    return; // Nothing to process
+  }
+
+  // Process all transactions with matching credit consumptions
+  let successCount = 0;
+  let skipCount = 0;
+  let errorCount = 0;
+
+  // First, create a copy of all credit consumptions to prevent early removal
+  const consumptionsByTx = new Map<string, CreditConsumption[]>();
+  for (const [txHash, consumptions] of pendingCreditConsumptions.entries()) {
+    consumptionsByTx.set(txHash, [...consumptions]);
+  }
+
+  // Create a copy of pendingTransactions to iterate through since we'll be modifying it
+  const pendingTxEntries = Array.from(pendingTransactions.entries());
+
+  // Process each transaction
+  for (const [txHash, txData] of pendingTxEntries) {
+    try {
+      const consumptions = consumptionsByTx.get(txHash) || [];
+
+      if (consumptions.length > 0) {
+        // Process each credit consumption for this transaction
+        if (consumptions.length > 1) {
+          console.log(
+            `[MANA] Processing ${consumptions.length} consumptions for tx ${txHash}`
+          );
+        }
+
+        // Process each consumption one by one
+        for (const consumption of consumptions) {
+          await createManaTransaction(store, txHash, consumption);
+          successCount++;
+        }
+      } else {
+        // Also create transactions for unmatched transfers
+        await createManaTransaction(store, txHash);
+        skipCount++;
+      }
+    } catch (error) {
+      console.error(
+        `[MANA] ERROR: Failed to process correlation for tx ${txHash}: ${error}`
+      );
+      errorCount++;
+    }
+  }
+
+  if (successCount > 0 || skipCount > 0 || errorCount > 0) {
+    console.log(
+      `[MANA] Correlation summary: ${successCount} processed, ${skipCount} skipped, ${errorCount} errors`
+    );
+  }
+
+  // Add detailed logging for orphaned credit consumptions
+  let remainingConsumptions = 0;
+  for (const consumptions of pendingCreditConsumptions.values()) {
+    remainingConsumptions += consumptions.length;
+  }
+
+  if (remainingConsumptions > 0) {
+    console.log(
+      `[MANA] ⚠️ WARNING: ${remainingConsumptions} orphaned consumptions detected - attempting recovery`
+    );
+
+    // Try to recover orphaned consumptions by checking for existing transactions in database
+    let recoveredCount = 0;
+    let stillOrphanedCount = 0;
+    const orphanedConsumptionIds: string[] = [];
+
+    // Process each remaining txHash with pending consumptions
+    for (const [txHash, consumptions] of pendingCreditConsumptions.entries()) {
+      // Try to find existing transactions in database for this txHash
+      try {
+        const existingTransactions = await store.find(ManaTransaction, {
+          where: { txHash },
+        });
+
+        if (existingTransactions.length > 0) {
+          // Update each transaction with these consumptions
+          for (const consumption of consumptions) {
+            let added = false;
+
+            // Try to add to each existing transaction
+            for (const existingTx of existingTransactions) {
+              // Get existing relatedConsumptionIds or initialize an empty array
+              const relatedIds = existingTx.relatedConsumptionIds || [];
+
+              // Add this consumption ID if not already present
+              if (!relatedIds.includes(consumption.id)) {
+                relatedIds.push(consumption.id);
+                existingTx.relatedConsumptionIds = relatedIds;
+
+                // Update credit amount
+                if (!existingTx.creditAmount) {
+                  existingTx.creditAmount = consumption.amount;
+                } else {
+                  existingTx.creditAmount += consumption.amount;
+                }
+
+                // Save the updated transaction
+                await store.save(existingTx);
+                added = true;
+                recoveredCount++;
+                break; // Successfully added to this transaction, no need to try others
+              }
+            }
+
+            // If couldn't add to any transaction, still orphaned
+            if (!added) {
+              orphanedConsumptionIds.push(consumption.id);
+              stillOrphanedCount++;
+            }
+          }
+        } else {
+          // No existing transactions, all consumptions still orphaned
+          for (const consumption of consumptions) {
+            orphanedConsumptionIds.push(consumption.id);
+            stillOrphanedCount++;
+          }
+        }
+      } catch (error) {
+        console.error(
+          `[MANA] ERROR: Failed to check for existing transactions: ${error}`
+        );
+
+        // Count these as still orphaned
+        for (const consumption of consumptions) {
+          orphanedConsumptionIds.push(consumption.id);
+          stillOrphanedCount++;
+        }
+      }
+    }
+
+    if (recoveredCount > 0 || stillOrphanedCount > 0) {
+      console.log(
+        `[MANA] Recovery summary: ${recoveredCount} recovered, ${stillOrphanedCount} still orphaned`
+      );
+    }
+
+    if (stillOrphanedCount > 0) {
+      // Only show first few IDs to avoid cluttering logs
+      const displayIds = orphanedConsumptionIds.slice(0, 3);
+      const remaining =
+        orphanedConsumptionIds.length > 3
+          ? `and ${orphanedConsumptionIds.length - 3} more`
+          : "";
+      console.log(
+        `[MANA] 🚨 ERROR: Remaining orphaned consumptions: ${displayIds.join(
+          ", "
+        )} ${remaining}`
+      );
+    }
+
+    // Clear remaining pending consumptions
+    pendingCreditConsumptions.clear();
+  }
+}

--- a/src/mana.ts
+++ b/src/mana.ts
@@ -7,599 +7,322 @@ import { formatMana, formatAddress } from "./utils";
 const DAO_ADDRESS = "0xb08e3e7cc815213304d884c88ca476ebc50eaab2";
 
 /**
- * Transaction data structure with all relevant information
+ * Find all MANA transfers in a set of logs for a specific transaction
  */
-interface TransactionData {
-  transfers: Array<{
-    fromAddress: string;
-    toAddress: string;
-    totalManaAmount: bigint;
-    timestamp: Date;
-    block: number;
-    logIndex: number;
-    isDaoFee: boolean;
-  }>;
-  creditBeneficiaries: string[]; // Array of users who benefited from credits in this tx
-  totalDaoFees: bigint;
-  timestamp: Date;
-  block: number;
+export function findManaTransfersInBlock(
+  logs: any[],
+  manaContractAddress: string,
+  ERC20Events: any,
+  timestamp: Date,
+  blockHeight: number
+): any[] {
+  const manaTransfers = [];
+
+  for (const log of logs) {
+    if (
+      log.address === manaContractAddress &&
+      log.topics[0] === ERC20Events.Transfer.topic
+    ) {
+      const { from, to, value } = ERC20Events.Transfer.decode(log);
+      const normalizedFrom = from.toLowerCase();
+      const normalizedTo = to.toLowerCase();
+
+      // Check if this is a DAO fee transfer
+      const isDaoFee = normalizedTo === DAO_ADDRESS.toLowerCase();
+
+      console.log(
+        `[MANA] 🪙 Transfer: ${normalizedFrom} → ${normalizedTo}, amount: ${formatMana(
+          value
+        )}, block: ${blockHeight}. ${isDaoFee ? "DAO fee 💰" : ""}`
+      );
+
+      manaTransfers.push({
+        fromAddress: normalizedFrom,
+        toAddress: normalizedTo,
+        totalManaAmount: value,
+        timestamp,
+        block: blockHeight,
+        logIndex: log.logIndex,
+        isDaoFee,
+      });
+    }
+  }
+
+  return manaTransfers;
 }
 
 /**
- * Map to track MANA transfers by transaction hash for correlation with credit usage
+ * Create MANA Transaction entities from the collected transfers and consumptions
  */
-const pendingTransactions = new Map<string, TransactionData>();
-
-/**
- * Map to track credit consumptions by transaction hash for correlation with MANA transfers
- * Each transaction hash can have multiple consumptions
- */
-const pendingCreditConsumptions = new Map<string, CreditConsumption[]>();
-
-/**
- * Process a MANA transfer event
- */
-export function processManaTransfer(
-  store: Store,
-  log: Log & { transactionHash: string },
-  from: string,
-  to: string,
-  amount: bigint,
-  timestamp: Date,
-  block: number,
-  creditsContractAddress: string
-): void {
-  // Get transaction hash via the transaction accessor
-  const txHash = log.transactionHash;
-  if (!txHash) {
-    console.log(
-      "[MANA] ERROR: No transaction hash available for MANA transfer"
-    );
-    return;
-  }
-
-  // Normalize addresses for comparison
-  const normalizedFrom = from.toLowerCase();
-  const normalizedTo = to.toLowerCase();
-  const normalizedCreditsContract = creditsContractAddress.toLowerCase();
-
-  // Check if this is a credits-related transfer
-  const isCreditsInvolved =
-    normalizedFrom === normalizedCreditsContract ||
-    normalizedTo === normalizedCreditsContract;
-
-  // Check if this is a DAO fee transfer
-  const isDaoFee = normalizedTo === DAO_ADDRESS;
-
-  // We also want to track transfers FROM a beneficiary as they might be paying for credits
-  const isPotentialUserPayment = pendingCreditConsumptions.has(txHash);
-
-  // We only want to track:
-  // 1. Credits-related transfers
-  // 2. DAO fees ONLY if we're already tracking the transaction (involves credits)
-  // 3. User payments for transactions with pending credit consumptions
-  if (
-    !isCreditsInvolved &&
-    !(isDaoFee && pendingTransactions.has(txHash)) &&
-    !isPotentialUserPayment
-  ) {
-    return;
-  }
-
-  // Initialize transaction data if not already tracking
-  if (!pendingTransactions.has(txHash)) {
-    pendingTransactions.set(txHash, {
-      transfers: [],
-      creditBeneficiaries: [],
-      totalDaoFees: 0n,
-      timestamp,
-      block,
-    });
-  }
-
-  // Get the transaction data
-  const txData = pendingTransactions.get(txHash)!;
-
-  // Add this transfer
-  txData.transfers.push({
-    fromAddress: normalizedFrom,
-    toAddress: normalizedTo,
-    totalManaAmount: amount,
-    timestamp,
-    block,
-    logIndex: log.logIndex,
-    isDaoFee,
-  });
-
-  // Add to DAO fees if applicable
-  if (isDaoFee) {
-    txData.totalDaoFees += amount;
-    console.log(`[MANA] 💰 DAO fee for tx ${txHash}: ${formatMana(amount)}`);
-  }
+export function createManaTransactions(
+  manaTransfersByTx: Map<string, any[]>,
+  creditConsumptionsByTx: Map<string, CreditConsumption[]>,
+  store: Store
+): ManaTransaction[] {
+  const manaTransactions: ManaTransaction[] = [];
+  const processedTxs = new Set<string>();
 
   console.log(
-    `[MANA] 🪙 Credits transfer: ${normalizedFrom} → ${normalizedTo}, amount: ${formatMana(
-      amount
-    )}`
+    `[MANA] Processing ${manaTransfersByTx.size} transactions with MANA transfers`
   );
 
-  // Check if we already have matching credit consumptions
-  if (pendingCreditConsumptions.has(txHash)) {
-    const creditConsumptions = pendingCreditConsumptions.get(txHash)!;
-    if (creditConsumptions.length > 1) {
-      console.log(
-        `[MANA] Processing ${creditConsumptions.length} consumptions for tx ${txHash}`
-      );
-    }
+  // First check transactions that have both MANA transfers and credit consumptions
+  for (const [txHash, consumptions] of creditConsumptionsByTx.entries()) {
+    const transfers = manaTransfersByTx.get(txHash) || [];
 
-    // Process each credit consumption
-    for (const creditConsumption of creditConsumptions) {
-      createManaTransaction(store, txHash, creditConsumption);
+    // Create a transaction even if no MANA transfers found (might be recovered later)
+    const transaction = createSingleManaTransaction(
+      txHash,
+      transfers,
+      consumptions
+    );
+    if (transaction) {
+      manaTransactions.push(transaction);
+      processedTxs.add(txHash);
     }
   }
+
+  // Check for MANA transfers without credit consumptions
+  for (const [txHash, transfers] of manaTransfersByTx.entries()) {
+    // Skip already processed transactions
+    if (processedTxs.has(txHash)) continue;
+
+    // Create a transaction for any remaining transfers
+    const transaction = createSingleManaTransaction(txHash, transfers, []);
+    if (transaction) {
+      manaTransactions.push(transaction);
+    }
+  }
+
+  // Check for orphaned credit consumptions (no matching transfers)
+  recoverOrphanedConsumptions(
+    creditConsumptionsByTx,
+    processedTxs,
+    manaTransactions,
+    store
+  );
+
+  return manaTransactions;
 }
 
 /**
- * Process a credit consumption event
+ * Create a single MANA Transaction entity for a given transaction hash
  */
-export async function registerCreditConsumption(
-  store: Store,
-  creditConsumption: CreditConsumption
-): Promise<void> {
-  const txHash = creditConsumption.txHash;
-  const consumptionId = creditConsumption.id;
-
-  // Initialize the array if it doesn't exist
-  if (!pendingCreditConsumptions.has(txHash)) {
-    pendingCreditConsumptions.set(txHash, []);
+function createSingleManaTransaction(
+  txHash: string,
+  transfers: any[],
+  consumptions: CreditConsumption[]
+): ManaTransaction | null {
+  if (transfers.length === 0 && consumptions.length === 0) {
+    return null;
   }
 
-  // Add this consumption to the array for this transaction
-  const consumptions = pendingCreditConsumptions.get(txHash)!;
+  // Sort transfers by amount (largest first)
+  const sortedTransfers = [...transfers].sort((a, b) =>
+    b.totalManaAmount > a.totalManaAmount
+      ? 1
+      : b.totalManaAmount < a.totalManaAmount
+      ? -1
+      : 0
+  );
 
-  // Check if this specific consumption is already in the array (avoid duplicates)
-  const existingIndex = consumptions.findIndex((c) => c.id === consumptionId);
-  if (existingIndex >= 0) {
-    console.log(
-      `[CREDITS] ERROR: Consumption ${consumptionId} already registered for tx ${txHash}, skipping`
-    );
-    return;
-  }
+  // Get main transfers (non-DAO fees)
+  const mainTransfers = sortedTransfers.filter((t) => !t.isDaoFee);
 
-  // Add to the array of consumptions for this transaction
-  consumptions.push(creditConsumption);
+  // Get DAO fee transfers
+  const daoFeeTransfers = sortedTransfers.filter((t) => t.isDaoFee);
 
-  // Store the beneficiary address if we're already tracking this transaction
-  if (pendingTransactions.has(txHash)) {
-    const txData = pendingTransactions.get(txHash)!;
-    const beneficiaryId = creditConsumption.beneficiary.id.toLowerCase();
+  // Calculate total DAO fees
+  const totalDaoFees = daoFeeTransfers.reduce(
+    (sum, t) => sum + t.totalManaAmount,
+    0n
+  );
 
-    // Add to the array of beneficiaries if not already there
-    if (!txData.creditBeneficiaries.includes(beneficiaryId)) {
-      txData.creditBeneficiaries.push(beneficiaryId);
-    }
+  // Get user addresses from credit consumptions
+  const beneficiaryAddresses = consumptions.map((c) =>
+    c.beneficiary.id.toLowerCase()
+  );
 
-    // Process this consumption immediately if we already have the transaction data
-    await createManaTransaction(store, txHash, creditConsumption);
+  // Find transfers from any of the beneficiaries (user payments)
+  const userTransfers = sortedTransfers.filter(
+    (t) => beneficiaryAddresses.includes(t.fromAddress) && !t.isDaoFee
+  );
+
+  // Calculate total user paid amount
+  const userPaidAmount = userTransfers.reduce(
+    (sum, t) => sum + t.totalManaAmount,
+    0n
+  );
+
+  // Calculate total credit amount from all consumptions
+  const creditAmount = consumptions.reduce((sum, c) => sum + c.amount, 0n);
+
+  // Get consumption IDs
+  const consumptionIds = consumptions.map((c) => c.id);
+
+  // If we have main transfers, use the largest one as the main transfer
+  // Otherwise, just create a placeholder with the consumption info
+  let fromAddress = "";
+  let toAddress = "";
+  let totalManaAmount = 0n;
+  let timestamp = new Date();
+  let blockHeight = 0;
+  let logIndex = 0;
+
+  if (mainTransfers.length > 0) {
+    // Use the largest transfer as the main one
+    const mainTransfer = mainTransfers[0];
+    fromAddress = mainTransfer.fromAddress;
+    toAddress = mainTransfer.toAddress;
+    totalManaAmount = mainTransfer.totalManaAmount;
+    timestamp = mainTransfer.timestamp;
+    blockHeight = mainTransfer.block;
+    logIndex = mainTransfer.logIndex;
+  } else if (consumptions.length > 0) {
+    // If no transfers but we have consumptions, use the first consumption's info
+    const firstConsumption = consumptions[0];
+    fromAddress = firstConsumption.beneficiary.id.toLowerCase();
+    toAddress = firstConsumption.contract.toLowerCase();
+    totalManaAmount = 0n; // No MANA transfer found yet
+    timestamp = firstConsumption.timestamp;
+    blockHeight = firstConsumption.block;
+    logIndex = 0; // No real log index available
   } else {
-    console.log(
-      `[CREDITS] ⚠️ WARNING: No MANA transfer found yet for consumption in tx ${txHash}`
-    );
+    // This shouldn't happen given our earlier check, but just in case
+    return null;
+  }
 
-    // Check if transaction already exists in database but was processed in a previous batch
+  // Generate ID for the transaction
+  const id = `${txHash}-${logIndex}`;
+
+  // Log transaction summary
+  const totalAmount = totalManaAmount + (totalDaoFees || 0n);
+  console.log(`[MANA] 💵 Transaction ${txHash} summary:`);
+  console.log(`  - Total: ${formatMana(totalAmount)}`);
+  console.log(`  - Main: ${formatMana(totalManaAmount)}`);
+  if (totalDaoFees > 0n)
+    console.log(`  - DAO fees: ${formatMana(totalDaoFees)}`);
+  if (creditAmount > 0n)
+    console.log(`  - Credits: ${formatMana(creditAmount)}`);
+  if (userPaidAmount > 0n)
+    console.log(`  - User paid: ${formatMana(userPaidAmount)}`);
+  console.log(`  - Consumptions: ${consumptionIds.length}`);
+
+  // Create the ManaTransaction entity
+  return new ManaTransaction({
+    id,
+    txHash,
+    fromAddress,
+    toAddress,
+    totalManaAmount,
+    creditAmount: creditAmount > 0n ? creditAmount : null,
+    userPaidAmount: userPaidAmount > 0n ? userPaidAmount : null,
+    daoFeeAmount: totalDaoFees > 0n ? totalDaoFees : null,
+    relatedConsumptionIds: consumptionIds.length > 0 ? consumptionIds : [],
+    timestamp,
+    block: blockHeight,
+  });
+}
+
+/**
+ * Try to recover orphaned consumptions by checking for existing transactions
+ */
+async function recoverOrphanedConsumptions(
+  creditConsumptionsByTx: Map<string, CreditConsumption[]>,
+  processedTxs: Set<string>,
+  manaTransactions: ManaTransaction[],
+  store: Store
+): Promise<void> {
+  let orphanedTxCount = 0;
+  let orphanedConsumptionCount = 0;
+  let recoveredCount = 0;
+
+  for (const [txHash, consumptions] of creditConsumptionsByTx.entries()) {
+    // Skip transactions that were already processed
+    if (processedTxs.has(txHash)) continue;
+
+    orphanedTxCount++;
+    orphanedConsumptionCount += consumptions.length;
+
+    // Try to find existing transactions in database for this txHash
     try {
-      // Query with a prefix search for any transaction with this txHash
       const existingTransactions = await store.find(ManaTransaction, {
         where: { txHash },
       });
 
       if (existingTransactions.length > 0) {
-        // Update each existing transaction with this consumption ID
-        for (const existingTx of existingTransactions) {
-          // Get existing relatedConsumptionIds or initialize an empty array
-          const relatedIds = existingTx.relatedConsumptionIds || [];
-
-          // Add this consumption ID if not already present
-          if (!relatedIds.includes(consumptionId)) {
-            relatedIds.push(consumptionId);
-            existingTx.relatedConsumptionIds = relatedIds;
-
-            // Update credit amount
-            if (!existingTx.creditAmount) {
-              existingTx.creditAmount = creditConsumption.amount;
-            } else {
-              existingTx.creditAmount += creditConsumption.amount;
-            }
-
-            // Save the updated transaction
-            await store.save(existingTx);
-            console.log(
-              `[CREDITS] Updated transaction ${existingTx.id} with consumption ${consumptionId}`
-            );
-
-            // Remove this consumption from pending since it's been processed
-            const updatedConsumptions = consumptions.filter(
-              (c) => c.id !== consumptionId
-            );
-            if (updatedConsumptions.length === 0) {
-              pendingCreditConsumptions.delete(txHash);
-            } else {
-              pendingCreditConsumptions.set(txHash, updatedConsumptions);
-            }
-
-            return; // Successfully processed this consumption
-          }
-        }
-      }
-    } catch (error) {
-      console.error(
-        `[CREDITS] ERROR: Failed to check for existing transactions: ${error}`
-      );
-    }
-  }
-}
-
-/**
- * Create a ManaTransaction entity correlating MANA transfer with credit consumption
- */
-export async function createManaTransaction(
-  store: Store,
-  txHash: string,
-  creditConsumption?: CreditConsumption
-): Promise<void> {
-  // Get the transaction data
-  const txData = pendingTransactions.get(txHash);
-  if (!txData || txData.transfers.length === 0) {
-    console.log(`[MANA] ERROR: No MANA transfers found for tx ${txHash}`);
-    return;
-  }
-
-  // Add beneficiary from credit consumption if not already set
-  if (
-    creditConsumption &&
-    !txData.creditBeneficiaries.includes(
-      creditConsumption.beneficiary.id.toLowerCase()
-    )
-  ) {
-    txData.creditBeneficiaries.push(
-      creditConsumption.beneficiary.id.toLowerCase()
-    );
-  }
-
-  // Get the main transfers (not DAO fees) sorted by amount
-  const mainTransfers = txData.transfers
-    .filter((t) => !t.isDaoFee)
-    .sort((a, b) =>
-      b.totalManaAmount > a.totalManaAmount
-        ? 1
-        : b.totalManaAmount < a.totalManaAmount
-        ? -1
-        : 0
-    );
-
-  if (mainTransfers.length === 0) {
-    console.log(
-      `[MANA] ERROR: Only found DAO fee transfers for tx ${txHash}, skipping`
-    );
-    return;
-  }
-
-  // The main transfer is usually the largest one from the credits contract
-  const mainTransfer = mainTransfers[0];
-
-  // Find any transfers from the beneficiary (user paid amount)
-  let userPaidAmount = 0n;
-
-  // Check all beneficiaries for this transaction
-  if (txData.creditBeneficiaries.length > 0) {
-    // Find all transfers from any of the beneficiaries
-    const userTransfers = txData.transfers.filter((t) => {
-      return txData.creditBeneficiaries.includes(t.fromAddress) && !t.isDaoFee;
-    });
-
-    userPaidAmount = userTransfers.reduce(
-      (sum, t) => sum + t.totalManaAmount,
-      0n
-    );
-  }
-
-  // Generate a unique ID for the transaction
-  const id = `${txHash}-${mainTransfer.logIndex}`;
-
-  // Get or update existing transaction
-  let manaTransaction: ManaTransaction | undefined;
-  try {
-    manaTransaction = await store.get(ManaTransaction, id);
-  } catch (error) {
-    if (!(error instanceof Error && error.message.includes("not found"))) {
-      console.error(
-        `[MANA] ERROR: Failed to check for existing transaction: ${error}`
-      );
-    }
-  }
-
-  // Initialize the related consumption IDs array
-  let relatedConsumptionIds: string[] = [];
-
-  // If transaction exists, get its existing consumption IDs
-  if (manaTransaction) {
-    relatedConsumptionIds = manaTransaction.relatedConsumptionIds || [];
-  }
-
-  // Add current consumption ID if provided and not already in the array
-  if (
-    creditConsumption &&
-    !relatedConsumptionIds.includes(creditConsumption.id)
-  ) {
-    relatedConsumptionIds.push(creditConsumption.id);
-  }
-
-  // Always check for all consumptions in this transaction, even when processing individual consumption
-  let creditAmount: bigint | null = null;
-
-  if (pendingCreditConsumptions.has(txHash)) {
-    // Sum up all credit consumptions for this transaction
-    creditAmount = pendingCreditConsumptions
-      .get(txHash)!
-      .reduce((sum, consumption) => sum + consumption.amount, 0n);
-
-    // Also add the current consumption if it's not in the pending list
-    if (
-      creditConsumption &&
-      !pendingCreditConsumptions
-        .get(txHash)!
-        .some((c) => c.id === creditConsumption.id)
-    ) {
-      creditAmount += creditConsumption.amount;
-    }
-  } else if (creditConsumption) {
-    // If we don't have any pending consumptions but have the current one
-    creditAmount = creditConsumption.amount;
-  }
-
-  // Calculate total transaction amount
-  const totalAmount = mainTransfer.totalManaAmount + txData.totalDaoFees;
-
-  console.log(`[MANA] 💵 Transaction ${txHash} summary:`);
-  console.log(`  - Total: ${formatMana(totalAmount)}`);
-  console.log(`  - Main: ${formatMana(mainTransfer.totalManaAmount)}`);
-  if (txData.totalDaoFees > 0)
-    console.log(`  - DAO fees: ${formatMana(txData.totalDaoFees)}`);
-  if (creditAmount) console.log(`  - Credits: ${formatMana(creditAmount)}`);
-  if (userPaidAmount > 0)
-    console.log(`  - User paid: ${formatMana(userPaidAmount)}`);
-  console.log(`  - Consumptions: ${relatedConsumptionIds.length}`);
-
-  // Create or update the entity
-  if (!manaTransaction) {
-    // Create new transaction
-    manaTransaction = new ManaTransaction({
-      id,
-      txHash,
-      fromAddress: mainTransfer.fromAddress,
-      toAddress: mainTransfer.toAddress,
-      totalManaAmount: mainTransfer.totalManaAmount,
-      creditAmount,
-      userPaidAmount: userPaidAmount > 0 ? userPaidAmount : null,
-      daoFeeAmount: txData.totalDaoFees > 0 ? txData.totalDaoFees : null,
-      relatedConsumptionIds,
-      timestamp: txData.timestamp,
-      block: txData.block,
-    });
-  } else {
-    // Update existing transaction
-    manaTransaction.totalManaAmount = mainTransfer.totalManaAmount;
-    manaTransaction.creditAmount = creditAmount;
-    manaTransaction.userPaidAmount = userPaidAmount > 0 ? userPaidAmount : null;
-    manaTransaction.daoFeeAmount =
-      txData.totalDaoFees > 0 ? txData.totalDaoFees : null;
-    manaTransaction.relatedConsumptionIds = relatedConsumptionIds;
-  }
-
-  // Save to database
-  try {
-    await store.save(manaTransaction);
-
-    // If this is a specific consumption, mark it as processed by removing from the pending list
-    if (creditConsumption) {
-      const consumptions = pendingCreditConsumptions.get(txHash) || [];
-      const updatedConsumptions = consumptions.filter(
-        (c) => c.id !== creditConsumption.id
-      );
-
-      if (updatedConsumptions.length === 0) {
-        // If no more consumptions for this txHash, remove the entry
-        pendingCreditConsumptions.delete(txHash);
-
-        // Only remove from pendingTransactions if no more consumptions for this txHash
-        pendingTransactions.delete(txHash);
-      } else {
-        // Otherwise update with the remaining consumptions
-        pendingCreditConsumptions.set(txHash, updatedConsumptions);
-      }
-    }
-  } catch (error) {
-    console.error(`[MANA] ERROR: Failed to save transaction: ${error}`);
-  }
-}
-
-/**
- * Process all pending correlations at the end of a batch
- */
-export async function processPendingCorrelations(store: Store): Promise<void> {
-  const txCount = pendingTransactions.size;
-
-  // Calculate total pending consumptions
-  let totalPendingConsumptions = 0;
-  for (const consumptions of pendingCreditConsumptions.values()) {
-    totalPendingConsumptions += consumptions.length;
-  }
-
-  const transferCount = Array.from(pendingTransactions.values()).reduce(
-    (sum, tx) => sum + tx.transfers.length,
-    0
-  );
-
-  if (txCount > 0 || totalPendingConsumptions > 0) {
-    console.log(
-      `[MANA] Processing ${txCount} pending transactions with ${transferCount} transfers and ${totalPendingConsumptions} pending consumptions`
-    );
-  } else {
-    return; // Nothing to process
-  }
-
-  // Process all transactions with matching credit consumptions
-  let successCount = 0;
-  let skipCount = 0;
-  let errorCount = 0;
-
-  // First, create a copy of all credit consumptions to prevent early removal
-  const consumptionsByTx = new Map<string, CreditConsumption[]>();
-  for (const [txHash, consumptions] of pendingCreditConsumptions.entries()) {
-    consumptionsByTx.set(txHash, [...consumptions]);
-  }
-
-  // Create a copy of pendingTransactions to iterate through since we'll be modifying it
-  const pendingTxEntries = Array.from(pendingTransactions.entries());
-
-  // Process each transaction
-  for (const [txHash, txData] of pendingTxEntries) {
-    try {
-      const consumptions = consumptionsByTx.get(txHash) || [];
-
-      if (consumptions.length > 0) {
-        // Process each credit consumption for this transaction
-        if (consumptions.length > 1) {
-          console.log(
-            `[MANA] Processing ${consumptions.length} consumptions for tx ${txHash}`
-          );
-        }
-
-        // Process each consumption one by one
+        // Process consumptions against existing transactions
         for (const consumption of consumptions) {
-          await createManaTransaction(store, txHash, consumption);
-          successCount++;
-        }
-      } else {
-        // Also create transactions for unmatched transfers
-        await createManaTransaction(store, txHash);
-        skipCount++;
-      }
-    } catch (error) {
-      console.error(
-        `[MANA] ERROR: Failed to process correlation for tx ${txHash}: ${error}`
-      );
-      errorCount++;
-    }
-  }
+          let added = false;
 
-  if (successCount > 0 || skipCount > 0 || errorCount > 0) {
-    console.log(
-      `[MANA] Correlation summary: ${successCount} processed, ${skipCount} skipped, ${errorCount} errors`
-    );
-  }
+          // Try to add to each existing transaction
+          for (const existingTx of existingTransactions) {
+            // Clone the existing transaction for modification
+            const updatedTx = new ManaTransaction({
+              ...existingTx,
+            });
 
-  // Add detailed logging for orphaned credit consumptions
-  let remainingConsumptions = 0;
-  for (const consumptions of pendingCreditConsumptions.values()) {
-    remainingConsumptions += consumptions.length;
-  }
+            // Get existing relatedConsumptionIds or initialize an empty array
+            const relatedIds = updatedTx.relatedConsumptionIds || [];
 
-  if (remainingConsumptions > 0) {
-    console.log(
-      `[MANA] ⚠️ WARNING: ${remainingConsumptions} orphaned consumptions detected - attempting recovery`
-    );
+            // Add this consumption ID if not already present
+            if (!relatedIds.includes(consumption.id)) {
+              relatedIds.push(consumption.id);
+              updatedTx.relatedConsumptionIds = relatedIds;
 
-    // Try to recover orphaned consumptions by checking for existing transactions in database
-    let recoveredCount = 0;
-    let stillOrphanedCount = 0;
-    const orphanedConsumptionIds: string[] = [];
-
-    // Process each remaining txHash with pending consumptions
-    for (const [txHash, consumptions] of pendingCreditConsumptions.entries()) {
-      // Try to find existing transactions in database for this txHash
-      try {
-        const existingTransactions = await store.find(ManaTransaction, {
-          where: { txHash },
-        });
-
-        if (existingTransactions.length > 0) {
-          // Update each transaction with these consumptions
-          for (const consumption of consumptions) {
-            let added = false;
-
-            // Try to add to each existing transaction
-            for (const existingTx of existingTransactions) {
-              // Get existing relatedConsumptionIds or initialize an empty array
-              const relatedIds = existingTx.relatedConsumptionIds || [];
-
-              // Add this consumption ID if not already present
-              if (!relatedIds.includes(consumption.id)) {
-                relatedIds.push(consumption.id);
-                existingTx.relatedConsumptionIds = relatedIds;
-
-                // Update credit amount
-                if (!existingTx.creditAmount) {
-                  existingTx.creditAmount = consumption.amount;
-                } else {
-                  existingTx.creditAmount += consumption.amount;
-                }
-
-                // Save the updated transaction
-                await store.save(existingTx);
-                added = true;
-                recoveredCount++;
-                break; // Successfully added to this transaction, no need to try others
+              // Update credit amount
+              if (!updatedTx.creditAmount) {
+                updatedTx.creditAmount = consumption.amount;
+              } else {
+                updatedTx.creditAmount += consumption.amount;
               }
-            }
 
-            // If couldn't add to any transaction, still orphaned
-            if (!added) {
-              orphanedConsumptionIds.push(consumption.id);
-              stillOrphanedCount++;
+              // Add to our list of transactions to save
+              manaTransactions.push(updatedTx);
+              added = true;
+              recoveredCount++;
+              break; // Successfully added to this transaction
             }
           }
-        } else {
-          // No existing transactions, all consumptions still orphaned
-          for (const consumption of consumptions) {
-            orphanedConsumptionIds.push(consumption.id);
-            stillOrphanedCount++;
+
+          // If we couldn't add to any existing transaction, create a new one
+          if (!added) {
+            const newTx = createSingleManaTransaction(
+              txHash,
+              [],
+              [consumption]
+            );
+            if (newTx) {
+              manaTransactions.push(newTx);
+              recoveredCount++;
+            }
           }
         }
-      } catch (error) {
-        console.error(
-          `[MANA] ERROR: Failed to check for existing transactions: ${error}`
-        );
-
-        // Count these as still orphaned
-        for (const consumption of consumptions) {
-          orphanedConsumptionIds.push(consumption.id);
-          stillOrphanedCount++;
+      } else {
+        // No existing transactions, create new ones for these consumptions
+        const newTx = createSingleManaTransaction(txHash, [], consumptions);
+        if (newTx) {
+          manaTransactions.push(newTx);
+          recoveredCount += consumptions.length;
         }
       }
-    }
-
-    if (recoveredCount > 0 || stillOrphanedCount > 0) {
-      console.log(
-        `[MANA] Recovery summary: ${recoveredCount} recovered, ${stillOrphanedCount} still orphaned`
+    } catch (error) {
+      console.error(
+        `[MANA] ERROR: Failed to check for existing transactions: ${error}`
       );
-    }
 
-    if (stillOrphanedCount > 0) {
-      // Only show first few IDs to avoid cluttering logs
-      const displayIds = orphanedConsumptionIds.slice(0, 3);
-      const remaining =
-        orphanedConsumptionIds.length > 3
-          ? `and ${orphanedConsumptionIds.length - 3} more`
-          : "";
-      console.log(
-        `[MANA] 🚨 ERROR: Remaining orphaned consumptions: ${displayIds.join(
-          ", "
-        )} ${remaining}`
-      );
+      // Create a new transaction for these orphaned consumptions
+      const newTx = createSingleManaTransaction(txHash, [], consumptions);
+      if (newTx) {
+        manaTransactions.push(newTx);
+        recoveredCount += consumptions.length;
+      }
     }
+  }
 
-    // Clear remaining pending consumptions
-    pendingCreditConsumptions.clear();
+  if (orphanedConsumptionCount > 0) {
+    console.log(
+      `[MANA] Orphaned consumption recovery: ${recoveredCount}/${orphanedConsumptionCount} consumptions processed from ${orphanedTxCount} transactions`
+    );
   }
 }

--- a/src/model/generated/index.ts
+++ b/src/model/generated/index.ts
@@ -1,4 +1,5 @@
 export * from "./creditConsumption.model"
+export * from "./manaTransaction.model"
 export * from "./userCreditStats.model"
 export * from "./hourlyCreditUsage.model"
 export * from "./dailyCreditUsage.model"

--- a/src/model/generated/manaTransaction.model.ts
+++ b/src/model/generated/manaTransaction.model.ts
@@ -1,0 +1,47 @@
+import {Entity as Entity_, Column as Column_, PrimaryColumn as PrimaryColumn_, StringColumn as StringColumn_, Index as Index_, BigIntColumn as BigIntColumn_, DateTimeColumn as DateTimeColumn_, IntColumn as IntColumn_} from "@subsquid/typeorm-store"
+
+/**
+ * Tracks MANA transactions correlated with credit usage
+ */
+@Entity_()
+export class ManaTransaction {
+    constructor(props?: Partial<ManaTransaction>) {
+        Object.assign(this, props)
+    }
+
+    @PrimaryColumn_()
+    id!: string
+
+    @Index_()
+    @StringColumn_({nullable: false})
+    txHash!: string
+
+    @Index_()
+    @StringColumn_({nullable: false})
+    fromAddress!: string
+
+    @Index_()
+    @StringColumn_({nullable: false})
+    toAddress!: string
+
+    @BigIntColumn_({nullable: false})
+    totalManaAmount!: bigint
+
+    @BigIntColumn_({nullable: true})
+    creditAmount!: bigint | undefined | null
+
+    @BigIntColumn_({nullable: true})
+    userPaidAmount!: bigint | undefined | null
+
+    @BigIntColumn_({nullable: true})
+    daoFeeAmount!: bigint | undefined | null
+
+    @StringColumn_({array: true, nullable: true})
+    relatedConsumptionIds!: (string)[] | undefined | null
+
+    @DateTimeColumn_({nullable: false})
+    timestamp!: Date
+
+    @IntColumn_({nullable: false})
+    block!: number
+}

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,0 +1,300 @@
+import { Store } from "@subsquid/typeorm-store";
+import {
+  CreditConsumption,
+  UserCreditStats,
+  HourlyCreditUsage,
+  DailyCreditUsage,
+} from "./model";
+
+/**
+ * Creates or updates user credit stats
+ */
+export async function updateUserStats(
+  store: Store,
+  userStats: Map<string, UserCreditStats>,
+  address: string,
+  amount: bigint,
+  timestamp: Date
+): Promise<UserCreditStats> {
+  let userStat = userStats.get(address);
+  
+  if (!userStat) {
+    const existingStats = await store.get(UserCreditStats, address);
+    console.log(
+      existingStats
+        ? `Found existing stats for user ${address}`
+        : `Creating new stats for user ${address}`
+    );
+
+    userStat =
+      existingStats ||
+      new UserCreditStats({
+        id: address,
+        address: address,
+        totalCreditsConsumed: 0n,
+      });
+    userStats.set(address, userStat);
+  }
+
+  const oldTotal = userStat.totalCreditsConsumed;
+  userStat.totalCreditsConsumed += amount;
+  userStat.lastCreditUsage = timestamp;
+
+  console.log(`Updated user stats:`, {
+    user: address,
+    oldTotal: oldTotal.toString(),
+    newTotal: userStat.totalCreditsConsumed.toString(),
+    lastUsage: userStat.lastCreditUsage,
+  });
+
+  return userStat;
+}
+
+/**
+ * Formats a date as YYYY-MM-DD
+ */
+export function formatDateKey(date: Date): string {
+  return `${date.getUTCFullYear()}-${String(
+    date.getUTCMonth() + 1
+  ).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")}`;
+}
+
+/**
+ * Formats a date as YYYY-MM-DD-HH
+ */
+export function formatHourKey(date: Date): string {
+  return `${formatDateKey(date)}-${String(date.getUTCHours()).padStart(2, "0")}`;
+}
+
+/**
+ * Updates hourly credit usage statistics
+ */
+export async function updateHourlyStats(
+  store: Store,
+  hourlyUsage: Map<string, HourlyCreditUsage>,
+  timestamp: Date,
+  amount: bigint
+): Promise<HourlyCreditUsage> {
+  const hourKey = formatHourKey(timestamp);
+  console.log(`Processing hourly stats for key ${hourKey}`);
+  
+  let hourUsage = hourlyUsage.get(hourKey);
+  if (!hourUsage) {
+    console.log(`No in-memory hourly stats for ${hourKey}, checking database...`);
+    const existingHourUsage = await store.get(HourlyCreditUsage, hourKey);
+    
+    if (existingHourUsage) {
+      console.log(
+        `Found existing hourly stats in DB: ${JSON.stringify({
+          id: existingHourUsage.id,
+          totalAmount: existingHourUsage.totalAmount.toString(),
+          usageCount: existingHourUsage.usageCount,
+        })}`
+      );
+    } else {
+      console.log(`No hourly stats in DB for ${hourKey}, creating new entry`);
+    }
+    
+    hourUsage =
+      existingHourUsage ||
+      new HourlyCreditUsage({
+        id: hourKey,
+        totalAmount: 0n,
+        usageCount: 0,
+        timestamp,
+      });
+  } else {
+    console.log(
+      `Using in-memory hourly stats for ${hourKey}: ${JSON.stringify({
+        totalAmount: hourUsage.totalAmount.toString(),
+        usageCount: hourUsage.usageCount,
+      })}`
+    );
+  }
+  
+  const prevHourAmount = hourUsage.totalAmount;
+  const prevHourCount = hourUsage.usageCount;
+  
+  hourUsage.totalAmount += amount;
+  hourUsage.usageCount += 1;
+  hourlyUsage.set(hourKey, hourUsage);
+  
+  console.log(
+    `Updated hourly stats: ${hourKey}: ${JSON.stringify({
+      prevAmount: prevHourAmount.toString(),
+      newAmount: hourUsage.totalAmount.toString(),
+      prevCount: prevHourCount,
+      newCount: hourUsage.usageCount,
+    })}`
+  );
+  
+  return hourUsage;
+}
+
+/**
+ * Updates daily credit usage statistics
+ */
+export async function updateDailyStats(
+  store: Store,
+  dailyUsage: Map<string, DailyCreditUsage>,
+  timestamp: Date,
+  amount: bigint
+): Promise<DailyCreditUsage> {
+  const dayKey = formatDateKey(timestamp);
+  console.log(`Processing daily stats for key ${dayKey}`);
+  
+  let dayUsage = dailyUsage.get(dayKey);
+  if (!dayUsage) {
+    console.log(`No in-memory daily stats for ${dayKey}, checking database...`);
+    const existingDayUsage = await store.get(DailyCreditUsage, dayKey);
+    
+    if (existingDayUsage) {
+      console.log(
+        `Found existing daily stats in DB: ${JSON.stringify({
+          id: existingDayUsage.id,
+          totalAmount: existingDayUsage.totalAmount.toString(),
+          usageCount: existingDayUsage.usageCount,
+          uniqueUsers: existingDayUsage.uniqueUsers,
+        })}`
+      );
+    } else {
+      console.log(`No daily stats in DB for ${dayKey}, creating new entry`);
+    }
+    
+    dayUsage =
+      existingDayUsage ||
+      new DailyCreditUsage({
+        id: dayKey,
+        totalAmount: 0n,
+        uniqueUsers: 0,
+        usageCount: 0,
+        timestamp,
+      });
+  } else {
+    console.log(
+      `Using in-memory daily stats for ${dayKey}: ${JSON.stringify({
+        totalAmount: dayUsage.totalAmount.toString(),
+        usageCount: dayUsage.usageCount,
+        uniqueUsers: dayUsage.uniqueUsers,
+      })}`
+    );
+  }
+  
+  const prevDayAmount = dayUsage.totalAmount;
+  const prevDayCount = dayUsage.usageCount;
+  
+  dayUsage.totalAmount += amount;
+  dayUsage.usageCount += 1;
+  dailyUsage.set(dayKey, dayUsage);
+  
+  console.log(
+    `Updated daily stats: ${dayKey}: ${JSON.stringify({
+      prevAmount: prevDayAmount.toString(),
+      newAmount: dayUsage.totalAmount.toString(),
+      prevCount: prevDayCount,
+      newCount: dayUsage.usageCount,
+    })}`
+  );
+  
+  return dayUsage;
+}
+
+/**
+ * Updates unique users count for daily statistics
+ */
+export function updateUniqueUserCounts(
+  dailyUsage: Map<string, DailyCreditUsage>,
+  consumptions: CreditConsumption[]
+): void {
+  if (dailyUsage.size === 0) return;
+  
+  console.log("\nUpdating daily unique users counts...");
+  
+  for (let [dayKey, usage] of dailyUsage) {
+    console.log(`Calculating unique users for day ${dayKey}`);
+    
+    const matchingConsumptions = consumptions.filter((c) => {
+      const d = c.timestamp;
+      const consumptionDayKey = formatDateKey(d);
+      
+      const matches = consumptionDayKey === dayKey;
+      if (matches) {
+        console.log(`Matched consumption ${c.id} to day ${dayKey}`);
+      }
+      return matches;
+    });
+    
+    console.log(`Found ${matchingConsumptions.length} consumptions for day ${dayKey}`);
+    
+    const userIds = matchingConsumptions.map((c) => c.beneficiary.id);
+    console.log(`User IDs for day ${dayKey}: ${userIds.join(", ")}`);
+    
+    const uniqueUsers = new Set(userIds);
+    usage.uniqueUsers = uniqueUsers.size;
+    
+    console.log(
+      `Day ${dayKey}: ${usage.uniqueUsers} unique users (${Array.from(uniqueUsers).join(", ")})`
+    );
+  }
+}
+
+/**
+ * Filters out duplicate consumption records before saving
+ */
+export function getUniqueConsumptions(consumptions: CreditConsumption[]): CreditConsumption[] {
+  const consumptionIds = new Set<string>();
+  const uniqueConsumptions = consumptions.filter((c) => {
+    if (consumptionIds.has(c.id)) {
+      console.log(`WARNING: Removing duplicate consumption record with ID ${c.id} before saving`);
+      return false;
+    }
+    consumptionIds.add(c.id);
+    return true;
+  });
+
+  if (uniqueConsumptions.length !== consumptions.length) {
+    console.log(
+      `WARNING: Removed ${
+        consumptions.length - uniqueConsumptions.length
+      } duplicate consumption records`
+    );
+  }
+  
+  return uniqueConsumptions;
+}
+
+/**
+ * Debugs entities to be saved
+ */
+export function logEntitiesToSave(
+  userStats: Map<string, UserCreditStats>,
+  hourlyUsage: Map<string, HourlyCreditUsage>,
+  dailyUsage: Map<string, DailyCreditUsage>,
+  consumptions: CreditConsumption[]
+): void {
+  console.log("\nSaving entities to database...");
+  console.log(`- ${userStats.size} user stats`);
+  console.log(`- ${hourlyUsage.size} hourly records`);
+  console.log(`- ${dailyUsage.size} daily records`);
+  console.log(`- ${consumptions.length} consumption records`);
+  
+  // Debug hourly usage entities
+  console.log("\nDEBUG: Hourly usage records to save:");
+  for (const [key, usage] of hourlyUsage.entries()) {
+    console.log(
+      `  - Hour ${key}: amount=${usage.totalAmount.toString()}, count=${
+        usage.usageCount
+      }`
+    );
+  }
+  
+  // Debug daily usage entities
+  console.log("\nDEBUG: Daily usage records to save:");
+  for (const [key, usage] of dailyUsage.entries()) {
+    console.log(
+      `  - Day ${key}: amount=${usage.totalAmount.toString()}, count=${
+        usage.usageCount
+      }, uniqueUsers=${usage.uniqueUsers}`
+    );
+  }
+} 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,9 @@
+export type ManaTransfer = {
+  fromAddress: string;
+  toAddress: string;
+  totalManaAmount: bigint;
+  timestamp: Date;
+  block: number;
+  logIndex: number;
+  isDaoFee: boolean;
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@
  */
 export function formatMana(wei: bigint): string {
   const mana = Number(wei) / 1e18;
-  return `${wei.toString()} wei (${mana.toFixed(2)} MANA)`;
+  return `${wei.toString()} wei (${mana.toFixed(5)} MANA)`;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Format Wei value to MANA (ETH format)
+ * @param wei The amount in wei
+ * @returns Formatted string with wei value and MANA equivalent
+ */
+export function formatMana(wei: bigint): string {
+  const mana = Number(wei) / 1e18;
+  return `${wei.toString()} wei (${mana.toFixed(2)} MANA)`;
+}
+
+/**
+ * Format an Ethereum address
+ * @param address The Ethereum address
+ * @param trimmed Whether to trim the address (default: false)
+ * @returns Formatted address
+ */
+export function formatAddress(address: string, trimmed: boolean = false): string {
+  if (!address) return '';
+  
+  if (trimmed) {
+    return `${address.substring(0, 8)}...${address.substring(address.length - 6)}`;
+  }
+  
+  return address;
+} 


### PR DESCRIPTION
# Credits System: MANA Transaction Tracking Improvements

## Overview

We've implemented significant improvements to the blockchain processor for tracking credit usage and MANA token transfers on the Polygon network, with a focus on better tracking and correlating MANA transactions with credit consumptions.

## ManaTransaction Entity

The `ManaTransaction` entity tracks and correlates MANA transfers with credit usage, storing:

- Transaction details (hash, block, timestamp)
- Sender and recipient addresses
- Total MANA amount transferred
- Credit amount consumed
- User paid amount
- DAO fee amount
- Related credit consumption IDs

## Relevant MANA Transfers Filtering

We now only track MANA transfers that are directly relevant to the credit system:

1. **FROM credit manager TO creator** (creator payments)
2. **FROM credit manager TO DAO** (DAO fees)
3. **FROM user TO credit manager** (user payments for credits)

## Role-Based Transaction Tracking

Each address is now labeled with its role in the transaction:
- `[CreditsManager]` - The Credit Manager contract
- `[CREATOR]` - Content creators receiving payments
- `[DAO]` - The DAO address receiving fees
- `[USER]` - Users paying for credits

## Transaction Processing Improvements

The code now:

1. Collects MANA transfers once per block rather than for each consumption event
2. Correlates credit consumptions with relevant MANA transfers
3. Handles transactions with consumptions but no MANA transfers
4. Calculates the split between creator fees, DAO fees, and user payments

## DAO Fee Tracking

DAO fee tracking improvements:

1. Only track DAO fees coming from the Credit Manager
2. Fixed calculation bug in totalManaAmount to include DAO fees
3. Clear separation between creator payments and DAO fees
