### PR TITLE
fix: install awscli with --break-system-packages on node:24-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,11 @@ RUN echo -e "loglevel=silent\\nupdate-notifier=false" > /squid/.npmrc
 RUN npm i -g @subsquid/cli@latest && mv $(which sqd) /usr/local/bin/sqd
 
 # Install jq and AWS CLI v1
+# --break-system-packages: node:24-alpine ships Python 3.12, which marks the system
+# environment as externally managed (PEP 668) and refuses a plain `pip3 install`. This
+# is a throwaway container layer, so installing into the system site-packages is fine.
 RUN apk update && apk add --no-cache tini postgresql-client curl jq python3 py3-pip \
-    && pip3 install awscli \
+    && pip3 install awscli --break-system-packages \
     && rm -rf /var/cache/apk/*
 
 ENV PROMETHEUS_PORT 3001


### PR DESCRIPTION
## Problem

The release/CD image build on \`main\` is failing at the \`pip3 install awscli\` step:

\`\`\`
error: externally-managed-environment
Error: building at STEP "RUN apk update && apk add ... && pip3 install awscli ...": exit status 1
\`\`\`

(e.g. [run 26878328495](https://github.com/decentraland/credits-squid-core/actions/runs/26878328495))

### Root cause

#26 ("update Node.js to 24") moved the base image to \`node:24-alpine\`, which ships **Python 3.12**. Python 3.12 marks the system environment as *externally managed* ([PEP 668](https://peps.python.org/pep-0668/)), so a plain system-wide \`pip3 install\` is refused. This isn't code-related — \`npm run build\` (tsc) passes; the failure is purely the Dockerfile's awscli install on the newer base image.

## Fix

\`awscli\` is required at runtime (\`indexer.sh\` calls \`aws ecs describe-tasks\`), so it has to stay. Pass \`--break-system-packages\` to \`pip3 install\` — the documented escape hatch for PEP 668, and safe here since it's a throwaway container layer installing into system site-packages.

Minimal one-line change; no behavior change to the indexer.