### PR TITLE
feat(across): surface real MANA cost (NAME + bridge/gas) in the Slack alert

### DIFF
--- a/db/migrations/1780500000000-Data.js
+++ b/db/migrations/1780500000000-Data.js
@@ -1,0 +1,14 @@
+module.exports = class Data1780500000000 {
+    name = 'Data1780500000000'
+
+    async up(db) {
+        // The MANA the executor actually spent on the swap (NAME price + bridge/gas overhead),
+        // distinct from input_amount which is the bridged leg (USDC). Nullable: rows indexed
+        // before this column existed keep NULL.
+        await db.query(`ALTER TABLE "across_order" ADD "input_mana_amount" numeric`)
+    }
+
+    async down(db) {
+        await db.query(`ALTER TABLE "across_order" DROP COLUMN "input_mana_amount"`)
+    }
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -55,7 +55,8 @@ type AcrossOrder @entity {
   recipient: String # Destination recipient (e.g. the MulticallHandler on Ethereum)
   inputToken: String # Token deposited on Polygon (normalized to 20-byte address)
   outputToken: String # Token to be delivered on the destination chain
-  inputAmount: BigInt # Amount deposited on Polygon
+  inputAmount: BigInt # Amount deposited on Polygon (the bridge leg, e.g. USDC)
+  inputManaAmount: BigInt # MANA the executor actually spent on the swap = NAME price + bridge/gas overhead (sum of MANA transferred out by the depositor in the source tx)
   outputAmount: BigInt # Amount to be delivered on the destination chain
   destinationChainId: BigInt # Destination chain ID (1 = Ethereum for the NAME-claim flow)
   txHash: String! @index # Polygon transaction hash (source)

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,8 @@ interface PendingOrderInfo {
   // bridgeInputToken disambiguates so Slack can format with the right decimals.
   bridgeInputAmount: bigint;
   bridgeInputToken: string | null;
+  // Across only: MANA the executor spent on the swap (NAME price + bridge/gas overhead).
+  manaSpent: bigint | null;
   creditCount: number;
   timestamp: Date;
   retryCount: number;
@@ -54,6 +56,27 @@ const pendingOrders = new Map<string, PendingOrderInfo>();
 // Normalize a bytes32-encoded address (left-padded) to a 20-byte hex address.
 function bytes32ToAddress(b32: string): string {
   return ("0x" + b32.slice(-40)).toLowerCase();
+}
+
+// Sum the MANA transferred OUT by `spender` within a single tx. For an Across credit deposit
+// the depositor (the executor) sends NAME_PRICE + the bridge/gas buffer into the swap, so this
+// is the real MANA cost of the operation — distinct from `inputAmount`, which is the bridged
+// leg (USDC) after the swap. Returns 0n if no such transfer is found.
+function sumManaSpentBy(
+  blockLogs: (Log & { transactionHash?: string })[],
+  txHash: string,
+  spender: string
+): bigint {
+  const spenderLc = spender.toLowerCase();
+  let total = 0n;
+  for (const log of blockLogs) {
+    if (log.address.toLowerCase() !== MANA_CONTRACT_ADDRESS) continue;
+    if (log.topics[0] !== ERC20Events.Transfer.topic) continue;
+    if ((log.transactionHash || "") !== txHash) continue;
+    const { from, value } = ERC20Events.Transfer.decode(log);
+    if (from.toLowerCase() === spenderLc) total += value;
+  }
+  return total;
 }
 const POLLING_INTERVAL_MS = 30000; // 30 seconds
 const MAX_RETRIES = 30; // ~15 minutes max polling
@@ -146,6 +169,7 @@ function buildCrossChainMessage(
   const messageOptions = {
     ...opts,
     executorAddress: info.executorAddress,
+    manaSpent: info.manaSpent,
   };
   return info.provider === "across"
     ? getAcrossCreditMessage(
@@ -658,6 +682,13 @@ initSlack()
                   inputToken: bytes32ToAddress(deposit.inputToken),
                   outputToken: bytes32ToAddress(deposit.outputToken),
                   inputAmount: deposit.inputAmount,
+                  // Real MANA cost: what the executor (depositor) put into the swap = NAME price
+                  // + bridge/gas overhead. Captured from the depositor's MANA-out in this tx.
+                  inputManaAmount: sumManaSpentBy(
+                    block.logs as (Log & { transactionHash?: string })[],
+                    txHash,
+                    bytes32ToAddress(deposit.depositor)
+                  ),
                   outputAmount: deposit.outputAmount,
                   destinationChainId: deposit.destinationChainId,
                   txHash,
@@ -811,6 +842,8 @@ initSlack()
                   totalCreditsUsed: squidOrder.totalCreditsUsed,
                   bridgeInputAmount: squidOrder.fromAmount ?? BigInt(0),
                   bridgeInputToken: squidOrder.fromToken ?? null,
+                  // Squid path doesn't track the MANA-spend breakdown (Across-only feature).
+                  manaSpent: null,
                   creditCount: squidOrder.creditIds.length,
                   timestamp: squidOrder.timestamp,
                   retryCount: 0,
@@ -878,7 +911,11 @@ initSlack()
                   acrossOrder.acrossStatus,
                   acrossOrder.timestamp,
                   acrossOrder.beneficiary ?? acrossOrder.depositor,
-                  { executorAddress: acrossOrder.depositor, actionsSucceeded }
+                  {
+                    executorAddress: acrossOrder.depositor,
+                    actionsSucceeded,
+                    manaSpent: acrossOrder.inputManaAmount,
+                  }
                 )
               );
 
@@ -906,6 +943,7 @@ initSlack()
                   totalCreditsUsed: acrossOrder.totalCreditsUsed,
                   bridgeInputAmount: acrossOrder.inputAmount ?? BigInt(0),
                   bridgeInputToken: acrossOrder.inputToken ?? null,
+                  manaSpent: acrossOrder.inputManaAmount ?? null,
                   creditCount: acrossOrder.creditIds.length,
                   timestamp: acrossOrder.timestamp,
                   retryCount: 0,

--- a/src/model/generated/acrossOrder.model.ts
+++ b/src/model/generated/acrossOrder.model.ts
@@ -46,6 +46,9 @@ export class AcrossOrder {
     inputAmount!: bigint | undefined | null
 
     @BigIntColumn_({nullable: true})
+    inputManaAmount!: bigint | undefined | null
+
+    @BigIntColumn_({nullable: true})
     outputAmount!: bigint | undefined | null
 
     @BigIntColumn_({nullable: true})

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -213,6 +213,8 @@ export function getAcrossCreditMessage(
     isStalled?: boolean;
     executorAddress?: string;
     actionsSucceeded?: boolean;
+    // MANA the executor actually spent on the swap (NAME price + bridge/gas overhead).
+    manaSpent?: bigint | null;
   } = {}
 ) {
   const polygonscanUrl = `https://polygonscan.com/tx/${polygonTxHash}`;
@@ -250,13 +252,27 @@ export function getAcrossCreditMessage(
       ? `\n*Executor:* \`${options.executorAddress}\``
       : "";
 
+  // Real MANA cost of the claim: what the executor put into the swap, broken down into the
+  // NAME price (covered by credits) and the bridge/gas overhead (the executor's own MANA).
+  // `bridgeInputAmount` below is the intermediate USDC actually bridged, not the cost.
+  const manaSpentLine =
+    options.manaSpent && options.manaSpent > 0n
+      ? `\n*MANA Spent:* \`${ethers.formatEther(
+          options.manaSpent
+        )}\` MANA (NAME \`${ethers.formatEther(
+          totalCreditsUsed
+        )}\` + bridge/gas \`${ethers.formatEther(
+          options.manaSpent - totalCreditsUsed
+        )}\`)`
+      : "";
+
   return `${header}${stalledNote}${actionsNote}
 
 *User:* \`${beneficiary}\`${executorLine}
 *Credits Used:* \`${creditCount}\` credits (\`${ethers.formatEther(
     totalCreditsUsed
-  )}\` MANA)
-*Bridge Input:* \`${formatBridgeAmount(bridgeInputAmount, bridgeInputToken)}\`
+  )}\` MANA)${manaSpentLine}
+*Bridged:* \`${formatBridgeAmount(bridgeInputAmount, bridgeInputToken)}\`
 
 *Deposit ID:* \`${depositId.slice(0, 18)}...\`
 *Across Status:* \`${acrossStatus || "unknown"}\`${


### PR DESCRIPTION
## Why

The Across credit alert showed `Bridge Input: 9.174566 USDC` — which is the **intermediate bridged leg** (the MANA swapped to USDC), not the cost. It's confusing: the user paid 100 MANA in credits, but the message makes it look like the op cost ~9 USDC. And it never showed the **real MANA cost** of the operation.

Verified on a live successful claim (Polygon tx `0xf7131a…`):
```
MANA 100.0000  CreditsManager → Executor   (the credit)
MANA 116.8034  Executor → swap             (real cost: 100 NAME + 16.80 bridge/gas)
USDC   9.174566 swap → AcrossSpokePool      (the bridged leg — what we showed before)
```

## What

Capture the MANA the executor actually spent = the sum of MANA transferred **out by the depositor** (the executor) in the source tx. That's `NAME_PRICE + the bridge/gas overhead` funded from the executor's own balance. Persist it as `AcrossOrder.inputManaAmount` and break it down in the alert:

**Before**
```
Credits Used: 1 credits (100.0 MANA)
Bridge Input: 9.174566 USDC
```
**After**
```
Credits Used: 1 credits (100.0 MANA)
MANA Spent:   116.80 MANA (NAME 100.0 + bridge/gas 16.80)
Bridged:      9.174566 USDC
```

Now the alert shows the actual cost (and the overhead), which is also what the cost-guard (#496) thresholds on — so successful and rejected alerts speak the same language.

## Changes

- `schema.graphql`: `AcrossOrder.inputManaAmount` (BigInt, nullable) + migration `1780500000000-Data.js` (`ALTER TABLE ... ADD input_mana_amount`).
- `src/main.ts`: `sumManaSpentBy()` sums the depositor's MANA-out in the tx; set on the order at build time and threaded through `PendingOrderInfo` so the poll-loop re-send keeps it.
- `src/slack.ts`: `MANA Spent` breakdown line; renamed the misleading `Bridge Input` → `Bridged`.

## Verification

`tsc --noEmit` clean. The `sumManaSpentBy` result was checked against the live tx above (executor MANA-out = 116.80). Squid path passes `manaSpent: null` (Across-only feature; the line is omitted when absent). No lint step in this repo.

> Branched off `main` (across tracking #25, #27 already merged). The migration is additive/nullable, so existing rows are unaffected.