### PR TITLE
fix(slack): stop duplicate notifications when a new squid re-indexes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -424,6 +424,18 @@ initSlack()
       const newOrderHashes = new Set<string>();
       const newAcrossDepositIds = new Set<string>();
 
+      // Snapshot the shared notification high-water mark ONCE per batch. Every Slack dedup
+      // decision below compares against this snapshot with a strict ">", and we advance the
+      // mark to the batch head at the end (only-forward). This is what stops a freshly deployed
+      // squid that re-indexes history from re-emitting notifications the promoted squid already
+      // sent: its snapshot is the promoted instance's head, so every replayed block is <= it and
+      // is skipped. Reading once (not per-event) lets a single tx's credit + cross-chain alerts
+      // both fire, since the marker doesn't move mid-batch.
+      const notifiedThroughBlock = await getLastNotified(ctx.store);
+      const alreadyNotified = (blockHeight: number): boolean =>
+        notifiedThroughBlock !== null &&
+        BigInt(blockHeight) <= notifiedThroughBlock;
+
       for (let block of ctx.blocks) {
         // Create a map of txHash -> logs for this block to efficiently find MANA transfers
         const logsByTxHash = new Map<
@@ -718,14 +730,11 @@ initSlack()
             }
             creditConsumptionsByTx.get(txHash)!.push(consumption);
 
-            // Send Slack notification for real-time consumption events
-            if (slackComponent) {
+            // Send Slack notification for real-time consumption events.
+            // Skip blocks already announced (by this or the promoted squid) — the mark is
+            // advanced once at the end of the batch, not here.
+            if (slackComponent && !alreadyNotified(block.header.height)) {
               try {
-                const lastNotified = await getLastNotified(ctx.store);
-                if (lastNotified && lastNotified > block.header.height) {
-                  // Skip unnecessary log
-                  continue;
-                }
                 await slackComponent.sendMessage(
                   SLACK_NOTIFICATIONS_CHANNEL,
                   getCreditUsedMessage(
@@ -737,7 +746,6 @@ initSlack()
                     timestamp
                   )
                 );
-                await setLastNotified(ctx.store, BigInt(block.header.height));
                 console.log(
                   `[SLACK] ✅ Sent notification for consumption ${salt}`
                 );
@@ -802,8 +810,7 @@ initSlack()
         // Send Slack notification with all accumulated credits
         if (slackComponent) {
           try {
-            const lastNotified = await getLastNotified(ctx.store);
-            if (!lastNotified || lastNotified <= squidOrder.blockNumber) {
+            if (!alreadyNotified(squidOrder.blockNumber)) {
               const slackResult = await slackComponent.sendMessage(
                 SLACK_CROSS_CHAIN_CHANNEL,
                 getCrossChainCreditMessage(
@@ -896,8 +903,7 @@ initSlack()
 
         if (slackComponent) {
           try {
-            const lastNotified = await getLastNotified(ctx.store);
-            if (!lastNotified || lastNotified <= acrossOrder.blockNumber) {
+            if (!alreadyNotified(acrossOrder.blockNumber)) {
               const slackResult = await slackComponent.sendMessage(
                 SLACK_CROSS_CHAIN_CHANNEL,
                 getAcrossCreditMessage(
@@ -975,6 +981,16 @@ initSlack()
       await ctx.store.save(manaTransactions);
       await ctx.store.save([...squidRouterOrders.values()]);
       await ctx.store.save([...acrossOrders.values()]);
+
+      // Advance the shared notification high-water mark to the batch head (only-forward, see
+      // setLastNotified). Doing it once per batch — not per credit event — means the mark tracks
+      // the chain head rather than lagging at the last credit block, so a re-indexing squid sees
+      // the promoted instance's head and skips everything below it. Gated on slackComponent so a
+      // notifications-disabled instance (e.g. local/dev) doesn't mark blocks as "announced".
+      const batchHeadBlock = ctx.blocks[ctx.blocks.length - 1]?.header.height;
+      if (slackComponent && batchHeadBlock !== undefined) {
+        await setLastNotified(ctx.store, BigInt(batchHeadBlock));
+      }
 
       // Only log batch completion if something was processed
       const totalEntities =

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -67,10 +67,16 @@ export async function getLastNotified(store: Store): Promise<bigint | null> {
   return lastNotified && BigInt(lastNotified);
 }
 
-export async function setLastNotified(store: Store, timestamp: bigint) {
+/**
+ * Advance the shared notification high-water mark. ONLY-FORWARD: a squid that is replaying
+ * history (e.g. a freshly deployed instance re-indexing from FROM_BLOCK) must never pull the
+ * mark backwards below where the promoted instance already notified, or it would re-emit
+ * notifications for blocks that were already announced. GREATEST keeps the max.
+ */
+export async function setLastNotified(store: Store, blockHeight: bigint) {
   const em = (store as unknown as { em: () => EntityManager }).em();
   await em.query(
-    `UPDATE public.squids SET last_notified = ${timestamp} WHERE name = 'credits'`
+    `UPDATE public.squids SET last_notified = GREATEST(COALESCE(last_notified, 0), ${blockHeight}) WHERE name = 'credits'`
   );
 }
 


### PR DESCRIPTION
## Symptom

After deploying a new squid (server A) that re-indexes from `FROM_BLOCK`, while the promoted instance (server B) was already live at the head, a **cross-chain credit alert was sent twice** for the same tx — server B's original (later edited to `filled`) and server A's re-emission during replay.

## Root cause

Both instances share `public.squids.last_notified` for dedup, but it was broken three ways:

1. **`last_notified` only advanced in the credit-used handler** — never in the cross-chain (Squid/Across) handlers. So it sat at the **last credit block**, not the chain head. When the replaying instance reached that block, the gate let it through.
2. **Non-strict boundary**: the cross-chain checks used `!lastNotified || lastNotified <= order.blockNumber`, so the block **equal to** `last_notified` re-notified.
3. **`setLastNotified` was unconditional** (`SET last_notified = X`), so a lagging instance could pull the mark **backwards**.

Net effect: on every deploy, the re-indexing squid re-announced the most recent credit op(s).

## Fix

- **Snapshot** `last_notified` once at the start of each batch; gate every Slack send on a strict **`block > snapshot`** (helper `alreadyNotified`). Reading once (not per-event) means a single tx's credit + cross-chain alerts still **both** fire, while a replay — whose snapshot is the promoted instance's head — skips every replayed block.
- **Advance the mark to the batch head once per batch** (not per credit event), so it tracks the **chain head** instead of lagging at the last credit block.
- **`setLastNotified` is now only-forward** (`GREATEST(COALESCE(last_notified,0), block)`), so a lagging instance can't regress it.
- Bonus: removing the old `continue` means the hourly/daily **credit stats updates no longer get skipped** on already-notified blocks (they're per-schema and should always run).

No schema change. `tsc` clean.

## Remaining (acceptable) edge

If two instances process the **exact same head block** concurrently within one batch window, a single duplicate is still possible — but that's a narrow race vs. the deploy-replay case this fixes. A future hardening could dedup per-deposit in a shared table.

> Branched off `main`. Touches the same cross-chain notification blocks as #28 (MANA cost breakdown) — minor, resolvable overlap if both land; happy to sequence them.