### PR TITLE
fix: grant squids table access on every indexer start

### DIFF
--- a/indexer.sh
+++ b/indexer.sh
@@ -72,14 +72,21 @@ else
     ALTER DEFAULT PRIVILEGES FOR ROLE $NEW_DB_USER IN SCHEMA $NEW_SCHEMA_NAME
       GRANT SELECT ON TABLES TO $CREDITS_SERVER_API_READER_USER;
 
-    -- Grant insert/update to squid public table
-    GRANT SELECT, INSERT, UPDATE ON TABLE $SQUIDS_PUBLIC_TABLE TO $NEW_DB_USER;
-
     -- Insert a new record into the indexers table
     INSERT INTO public.indexers (service, schema, db_user, created_at, commit_hash)
     VALUES ('$SERVICE_NAME', '$NEW_SCHEMA_NAME', '$NEW_DB_USER', NOW(), '$COMMIT_HASH');
 EOSQL
 fi
+
+# Ensure the squid runtime user can read/write the shared public.squids table on EVERY start.
+# This MUST run on both the new-user and the resume paths: a resumed user (existing indexer row)
+# skips the creation block above, and a user can also lose this grant if public.squids is recreated
+# out-of-band (the grant is tied to the table object, so adding/recreating it drops prior grants).
+# The processor reads public.squids (getLastNotified) on every batch, so a missing grant is FATAL
+# and crash-loops the whole indexer. GRANT is idempotent, so re-applying it each start is safe.
+psql -v ON_ERROR_STOP=1 --username "$DB_USER" --dbname "$DB_NAME" --host "$DB_HOST" --port "$DB_PORT" <<-EOSQL
+  GRANT SELECT, INSERT, UPDATE ON TABLE public.$SQUIDS_PUBLIC_TABLE TO $NEW_DB_USER;
+EOSQL
 
 # Unset PGPASSWORD
 unset PGPASSWORD

--- a/src/main.ts
+++ b/src/main.ts
@@ -431,7 +431,13 @@ initSlack()
       // sent: its snapshot is the promoted instance's head, so every replayed block is <= it and
       // is skipped. Reading once (not per-event) lets a single tx's credit + cross-chain alerts
       // both fire, since the marker doesn't move mid-batch.
-      const notifiedThroughBlock = await getLastNotified(ctx.store);
+      // Only read the shared marker when notifications are enabled. The mark is used purely to
+      // dedup Slack alerts (see alreadyNotified below), and setLastNotified is likewise gated on
+      // slackComponent — so a notifications-disabled instance (local/dev) never needs to touch
+      // public.squids at all, keeping it off the shared table and out of its permission surface.
+      const notifiedThroughBlock = slackComponent
+        ? await getLastNotified(ctx.store)
+        : null;
       const alreadyNotified = (blockHeight: number): boolean =>
         notifiedThroughBlock !== null &&
         BigInt(blockHeight) <= notifiedThroughBlock;


### PR DESCRIPTION
## Problem

The processor was crash-looping on startup with:

```
FATAL QueryFailedError: permission denied for table squids
  query: SELECT last_notified FROM public.squids WHERE name = 'credits'
  code: 42501
  at getLastNotified (/squid/lib/slack.js:41)
```

This is fatal: a failed read of the shared `public.squids` table kills the whole indexer, not just Slack notifications, and it restarts into the same error forever.

## Root cause

`credits-squid-core` is the only squid that **reads** the shared `public.squids` table from the *processor runtime user* (`$NEW_DB_USER`), via `getLastNotified()` which runs once per batch (added with the Slack notification dedup feature). The other squids only touch that table from the admin server.

`indexer.sh` granted `SELECT, INSERT, UPDATE ON squids` to the per-deploy user, but **only inside the new-user-creation (`else`) branch**. So the grant was:

- **skipped on the resume path** — an existing indexer (same service + commit) reuses its user and never re-applies the grant, and
- **lost if `public.squids` is recreated out-of-band** — grants are tied to the table object, so adding/recreating the table (e.g. when the `last_notified` column was introduced) drops prior grants.

Either way the runtime user ends up without `SELECT` on `public.squids` → `42501`.

## Changes

- **`indexer.sh`**: move the `GRANT SELECT, INSERT, UPDATE ON public.squids TO $NEW_DB_USER` out of the `else` branch into an unconditional step that runs on **every** start, for both the new-user and resume paths, as `$DB_USER` (the table owner) while `PGPASSWORD` is still set. `GRANT` is idempotent, so re-applying it each start is safe and also self-heals a user that lost the grant.
- **`src/main.ts`**: only call `getLastNotified()` when `slackComponent` is enabled (mirrors `setLastNotified`, already gated). The high-water mark is used purely to dedup Slack alerts, so a notifications-disabled instance (local/dev) no longer touches `public.squids` at all. No change to dedup behavior when notifications are on.

## Test plan

- [x] `npm run build` passes
- [ ] Deploy to non-mainnet: confirm processor advances past the first batch without `permission denied for table squids`
- [ ] Confirm Slack notification dedup still works on a re-indexing instance (no duplicate alerts)